### PR TITLE
src/kmod: Implement get_port_immutable() verb

### DIFF
--- a/src/kmod/backports.h
+++ b/src/kmod/backports.h
@@ -58,6 +58,9 @@
 /* Introduced in Linux commits a97e2d86a9b88 and 4cd7c9479aff3, which first
  * appeared in Linux 4.2-rc1. */
 #define HAVE_IB_PROCESS_MAD_SIZES 1
+/* Introduced in Linux commit 7738613e7cb41 and first appeared in
+ * Linux 4.2-rc1. */
+#define HAVE_IB_GET_PORT_IMMUTABLE 1
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)

--- a/src/kmod/main.c
+++ b/src/kmod/main.c
@@ -293,6 +293,9 @@ static struct siw_dev *siw_device_create(int list_index)
 	ofa_dev->dma_device = &usiw_generic_dma_device;
 	ofa_dev->query_device = siw_query_device;
 	ofa_dev->query_port = siw_query_port;
+#ifdef HAVE_IB_GET_PORT_IMMUTABLE
+	ofa_dev->get_port_immutable = urdma_port_immutable;
+#endif
 	ofa_dev->query_qp = siw_query_qp;
 	ofa_dev->modify_port = siw_modify_port;
 	ofa_dev->query_pkey = siw_query_pkey;

--- a/src/kmod/verbs.c
+++ b/src/kmod/verbs.c
@@ -1152,3 +1152,30 @@ int siw_post_srq_recv(struct ib_srq *ofa_srq, struct ib_recv_wr *wr,
 {
 	return -ENOSYS;
 }
+
+#ifdef HAVE_IB_GET_PORT_IMMUTABLE
+/*
+ * urdma_port_immutable()
+ *
+ * Set immutable port attributes.
+ *
+ * @ofa_dev:	OFA device structure
+ * @port_num:	port number
+ * @immutable:	structure containing immutable fields to fill in
+ */
+int urdma_port_immutable(struct ib_device *ibdev, u8 port_num,
+			struct ib_port_immutable *immutable)
+{
+	struct ib_port_attr attr;
+	int err;
+
+	err = siw_query_port(ibdev, port_num, &attr);
+	if (err)
+		return err;
+
+	immutable->pkey_tbl_len = attr.pkey_tbl_len;
+	immutable->gid_tbl_len = attr.gid_tbl_len;
+
+	return 0;
+}
+#endif

--- a/src/kmod/verbs.h
+++ b/src/kmod/verbs.h
@@ -116,4 +116,9 @@ extern int siw_no_mad(struct ib_device *ofa_dev, int flags, u8 port,
 		      u16 *out_mad_pkey_index);
 #endif
 
+#ifdef HAVE_IB_GET_PORT_IMMUTABLE
+extern int urdma_port_immutable(struct ib_device *ibdev, u8 port_num,
+				struct ib_port_immutable *immutable);
+#endif
+
 #endif


### PR DESCRIPTION
This PR contains a commit which is necessary for the urdma kernel driver to run on kernels >= 4.2.