### PR TITLE
Kernel module fixes

### DIFF
--- a/src/kmod/Makefile.in
+++ b/src/kmod/Makefile.in
@@ -44,7 +44,7 @@ SOURCES = ae.c backports.h cm.c cm.h debug.c debug.h iwarp.h main.c mem.c \
 all:
 	for i in $(SOURCES); do if [ ! -e $${i} ]; then ln -s @srcdir@/$${i} $${i}; fi; done
 	if [ ! -e urdma_kabi.h ]; then ln -s @top_srcdir@/include/urdma_kabi.h .; fi
-	make -C @KERNELDIR@ M=`pwd` top_srcdir=$(realpath @top_srcdir@) modules
+	make -C @KERNELDIR@ M=`pwd` top_srcdir=$(realpath @top_srcdir@) modules EXTRA_CFLAGS="-g -DDEBUG"
 
 Makefile: @srcdir@/Makefile.in
 	cd @top_builddir@; ./config.status

--- a/src/kmod/cm.h
+++ b/src/kmod/cm.h
@@ -47,6 +47,8 @@
 #include <rdma/iw_cm.h>
 
 
+#define URDMA_PDATA_LEN_MAX 512
+
 enum siw_cep_state {
 	SIW_EPSTATE_IDLE = 1,
 	SIW_EPSTATE_LISTENING,
@@ -62,7 +64,8 @@ enum siw_cep_state {
 
 struct siw_mpa_info {
 	struct mpa_rr	hdr;	/* peer mpa hdr in host byte order */
-	char		*pdata;
+	char		pdata[URDMA_PDATA_LEN_MAX];
+				/* private data, plus up to four pad bytes */
 	int		bytes_rcvd;
 	char		*send_pdata;
 	int		send_pdata_size;

--- a/src/kmod/verbs.c
+++ b/src/kmod/verbs.c
@@ -281,15 +281,10 @@ int siw_query_device(struct ib_device *ofa_dev, struct ib_device_attr *attr,
 #endif
 {
 	struct siw_dev *sdev = siw_dev_ofa2siw(ofa_dev);
-	/*
-	 * A process context is needed to report avail memory resources.
-	 */
-	if (in_interrupt())
-		return -EINVAL;
 
 	memset(attr, 0, sizeof *attr);
 
-	attr->max_mr_size = rlimit(RLIMIT_MEMLOCK); /* per process */
+	attr->max_mr_size = -1ULL;
 	attr->sys_image_guid = sdev->ofa_dev.node_guid;
 	attr->vendor_id = sdev->attrs.vendor_id;
 	attr->vendor_part_id = sdev->attrs.vendor_part_id;


### PR DESCRIPTION
One fixes a kernel panic caused because somehow `current->signal` was not valid when `siw_query_device()` was initially called by the IB core during `ib_register_device()`.  This code is also present in softiwarp.  The code which calls `query_device` during IB core device initialization was added in the following Linux commit during the v4.5 cycle:

> commit 3e153a93a1c12e3354dd38cca414fb51a15136a2
> Author: Ira Weiny <ira.weiny@intel.com>
> Date:   Fri Dec 18 10:59:44 2015 +0200
>
>    IB/core: Save the device attributes on the device structure
>    
>    This way both the IB core and upper level drivers can access these cached
>    device attributes rather than querying or caching them on their own.
>    
>    Signed-off-by: Ira Weiny <ira.weiny@intel.com>
>    Signed-off-by: Or Gerlitz <ogerlitz@mellanox.com>
>    Signed-off-by: Doug Ledford <dledford@redhat.com>

The other fixes the private data exchange, since we can't receive a datagram in pieces in UDP, so replace that whole function with a `kernel_recvmsg()` call which ultimately simplifies the code.