### PR TITLE
Userspace updates

### DIFF
--- a/src/liburdma/driver.c
+++ b/src/liburdma/driver.c
@@ -80,6 +80,12 @@
 static struct usiw_driver *driver;
 
 void
+driver_add_context(struct usiw_context *ctx)
+{
+	LIST_INSERT_HEAD(&driver->ctxs, ctx, driver_entry);
+} /* driver_add_context */
+
+void
 start_progress_thread(void)
 {
 	sem_post(&driver->go);
@@ -232,7 +238,6 @@ usiw_driver_init(int portid)
 
 	dev->urdmad_fd = driver->urdmad_fd;
 
-	LIST_INSERT_HEAD(&driver->devs, dev, driver_entry);
 	return &dev->vdev.device;
 } /* usiw_driver_init */
 
@@ -471,7 +476,7 @@ do_init_driver(void)
 	driver = calloc(1, sizeof(*driver));
 	if (!driver)
 		goto err;
-	LIST_INIT(&driver->devs);
+	LIST_INIT(&driver->ctxs);
 
 	driver->urdmad_fd = setup_socket(sock_name);
 	if (driver->urdmad_fd < 0)

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -2117,7 +2117,7 @@ int
 kni_loop(void *arg)
 {
 	struct usiw_driver *driver = arg;
-	struct usiw_device *dev, **dev_prev;
+	struct usiw_context *ctx, **ctx_prev;
 	struct usiw_qp *qp, **qp_prev;
 	struct rte_mbuf *rxmbuf[RX_BURST_SIZE];
 	unsigned int count;
@@ -2125,13 +2125,8 @@ kni_loop(void *arg)
 
 	sem_wait(&driver->go);
 	while (1) {
-		LIST_FOR_EACH(dev, &driver->devs, driver_entry, dev_prev) {
-			if (!dev->ctx) {
-				continue;
-			}
-
-			LIST_FOR_EACH(qp, &dev->ctx->qp_active,
-							ctx_entry, qp_prev) {
+		LIST_FOR_EACH(ctx, &driver->ctxs, driver_entry, ctx_prev) {
+			LIST_FOR_EACH(qp, &ctx->qp_active, ctx_entry, qp_prev) {
 				switch (rte_atomic16_read(&qp->shm_qp->conn_state)) {
 				case usiw_qp_connected:
 					/* start_qp() transitions to

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -2037,22 +2037,6 @@ usiw_do_destroy_qp(struct usiw_qp *qp)
 } /* usiw_do_destroy_qp */
 
 
-static struct usiw_qp *
-lookup_qp_id(struct usiw_context *ctx, uint32_t qp_id)
-{
-	struct usiw_qp *qp;
-
-	rte_spinlock_lock(&ctx->qp_lock);
-	HASH_FIND(hh, ctx->qp, &qp_id, sizeof(qp_id), qp);
-	rte_spinlock_unlock(&ctx->qp_lock);
-	if (qp) {
-		rte_atomic32_inc(&qp->refcnt);
-		return qp;
-	}
-	return NULL;
-} /* lookup_qp_id */
-
-
 static void
 start_qp(struct usiw_qp *qp)
 {

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -313,6 +313,7 @@ struct usiw_context {
 	struct verbs_context vcontext;
 	struct usiw_device *dev;
 	int event_fd;
+	LIST_ENTRY(usiw_context) driver_entry;
 	LIST_HEAD(usiw_qp_head, usiw_qp) qp_active;
 	rte_atomic32_t qp_init_count;
 		/**< The number of queue pairs in the INIT state. */
@@ -332,7 +333,6 @@ usiw_get_context(struct ibv_context *ctx)
 
 struct usiw_device {
 	struct verbs_device vdev;
-	LIST_ENTRY(usiw_device) driver_entry;
 	struct rte_mempool *rx_mempool;
 	struct rte_mempool *tx_ddp_mempool;
 	struct rte_mempool *tx_hdr_mempool;
@@ -352,7 +352,7 @@ struct usiw_driver {
 	struct nl_sock *sock;
 	struct nl_cache *link_cache;
 	struct nl_cache *addr_cache;
-	LIST_HEAD(usiw_device_list_head, usiw_device) devs;
+	LIST_HEAD(usiw_context_list_head, usiw_context) ctxs;
 	int urdmad_fd;
 	uint32_t lcore_mask[RTE_MAX_LCORE / 32];
 };
@@ -360,6 +360,11 @@ struct usiw_driver {
 /** Starts the progress thread. */
 void
 start_progress_thread(void);
+
+/** Adds an IB user context to the list of contexts to be managed by the
+ * progress thread. */
+void
+driver_add_context(struct usiw_context *ctx);
 
 struct usiw_mr **
 usiw_mr_lookup(struct usiw_mr_table *tbl, uint32_t rkey);

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -1437,7 +1437,6 @@ usiw_init_context(struct verbs_device *device, struct ibv_context *context,
 
 	dev = container_of(device, struct usiw_device, vdev);
 	ctx->dev = dev;
-	ctx->dev->ctx = ctx;
 
 	rte_atomic32_init(&ctx->qp_init_count);
 	LIST_INIT(&ctx->qp_active);
@@ -1445,12 +1444,16 @@ usiw_init_context(struct verbs_device *device, struct ibv_context *context,
 	ctx->qp = NULL;
 	rte_spinlock_init(&ctx->qp_lock);
 
+	driver_add_context(ctx);
 	return 0;
 } /* usiw_init_context */
 
 
 void
-usiw_uninit_context(__attribute__((unused)) struct verbs_device *device,
-		__attribute__((unused)) struct ibv_context *ib_ctx)
+usiw_uninit_context(struct verbs_device *device, struct ibv_context *ib_ctx)
 {
+	struct usiw_context *ctx = usiw_get_context(ib_ctx);
+	RTE_LOG(INFO, USER1, "close context %p for device %p\n",
+			(void *)ib_ctx, (void *)device);
+	LIST_REMOVE(ctx, driver_entry);
 } /* usiw_uninit_context */

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -908,8 +908,12 @@ usiw_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr)
 
 	ee->tx_head = ee->tx_pending;
 
+	/* Queue pairs start with two references; one for the internal qp_active
+	 * list that gets decremented when the progress thread notices that the
+	 * QP has reached the error state, and the other for the reference
+	 * returned to the user which will be freed by ibv_destroy_qp().  */
 	rte_atomic32_init(&qp->refcnt);
-	rte_atomic32_set(&qp->refcnt, 1);
+	rte_atomic32_set(&qp->refcnt, 2);
 
 	rte_spinlock_lock(&ctx->qp_lock);
 	rte_atomic32_inc(&ctx->qp_init_count);


### PR DESCRIPTION
This changeset fixes bugs related to ibv_context handling that caused a crash in openmpi.