### PR TITLE
More updates

### DIFF
--- a/README
+++ b/README
@@ -102,3 +102,12 @@ Known Issues
 
  - The progress thread will use 100% CPU since it must busy-poll on the KNI
    interfaces (there is no way to sleep until the process gets an event).
+
+ - urdma follows the RFC 5040 ordering rules strictly, meaning that it
+   can place data segments out of order if it receives them out of
+   order. This in turn means that if two RDMA WRITE requests are made
+   on overlapping buffers, urdma may place a data segment from the first
+   *after* the corresponding data segment from the second, thus leading
+   to a torn write from the perspective of the application. Thus
+   applications must not post multiple transfer requests on overlapping
+   buffers simultaneously if they depend on the data ordering.

--- a/include/urdmad_private.h
+++ b/include/urdmad_private.h
@@ -98,6 +98,8 @@ struct urdmad_qp {
 
 	uint16_t rx_desc_count;
 		/**< Hardware receive descriptors on this RX queue. */
+	uint16_t rx_burst_size;
+		/**< Size of array passed to rte_eth_rx_burst(). */
 	uint16_t mtu;
 		/**< Device MTU. */
 

--- a/include/urdmad_private.h
+++ b/include/urdmad_private.h
@@ -134,7 +134,10 @@ struct urdmad_sock_hello_req {
 
 struct urdmad_sock_hello_resp {
 	struct urdmad_sock_msg hdr;
+	uint16_t max_lcore;
+	uint16_t device_count;
 	uint32_t lcore_mask[RTE_MAX_LCORE / 32];
+	uint16_t max_qp[];
 };
 
 union urdmad_sock_any_msg {

--- a/include/urdmad_private.h
+++ b/include/urdmad_private.h
@@ -100,6 +100,8 @@ struct urdmad_qp {
 		/**< Hardware receive descriptors on this RX queue. */
 	uint16_t rx_burst_size;
 		/**< Size of array passed to rte_eth_rx_burst(). */
+	uint16_t tx_burst_size;
+		/**< Size of array passed to rte_eth_tx_burst(). */
 	uint16_t mtu;
 		/**< Device MTU. */
 

--- a/src/kmod/cm.c
+++ b/src/kmod/cm.c
@@ -306,8 +306,8 @@ static int siw_cm_upcall(struct siw_cep *cep, enum iw_cm_event_type reason,
 	}
 	if (reason == IW_CM_EVENT_CONNECT_REQUEST) {
 #if HAVE_RFC_6581
-		event.ird = cep->ird;
-		event.ord = cep->ord;
+		event.ird = cep->ord;
+		event.ord = cep->ird;
 #endif
 		event.provider_data = cep;
 		cm_id = cep->listen_cep->cm_id;
@@ -611,8 +611,8 @@ static int siw_proc_trpreply(struct siw_cep *cep)
 	}
 
 	memset(&qp_attrs, 0, sizeof qp_attrs);
-	qp_attrs.irq_size = min(htons(rep->params.ord), qp->attrs.irq_size);
-	qp_attrs.orq_size = max(htons(rep->params.ird), qp->attrs.orq_size);
+	qp_attrs.irq_size = max(htons(rep->params.ord), cep->ird);
+	qp_attrs.orq_size = min(htons(rep->params.ird), cep->ord);
 	qp_attrs.llp_stream_handle = cep->llp.sock;
 	qp_attrs.state = SIW_QP_STATE_RTS;
 

--- a/src/kmod/main.c
+++ b/src/kmod/main.c
@@ -654,6 +654,8 @@ static struct siw_dev *siw_device_create(struct net_device *netdev)
 	ofa_dev->iwcm->add_ref = siw_qp_get_ref;
 	ofa_dev->iwcm->rem_ref = siw_qp_put_ref;
 	ofa_dev->iwcm->get_qp = siw_get_ofaqp;
+	strncpy(ofa_dev->iwcm->ifname, netdev->name,
+						sizeof(ofa_dev->iwcm->ifname));
 	/*
 	 * set and register sw version + user if type
 	 */

--- a/src/kmod/verbs.c
+++ b/src/kmod/verbs.c
@@ -134,6 +134,10 @@ static ssize_t siw_event_file_write(struct file *filp, const char __user *buf,
 		}
 		cq_event = (struct urdma_cq_event *)&event;
 		cq = siw_cq_id2obj(file->ctx->sdev, cq_event->cq_id);
+		if (WARN_ON_ONCE(!cq)) {
+			rv = -EINVAL;
+			goto out;
+		}
 		cq->ofa_cq.comp_handler(&cq->ofa_cq, cq->ofa_cq.cq_context);
 		siw_cq_put(cq);
 		break;

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -981,8 +981,8 @@ do_rdmap_read_request(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 		return;
 	}
 
-	if (qp->ird_active >= qp->shm_qp->ird_max) {
-		/* Cannot issue more than ird_max simultaneous RDMA READ
+	if (qp->ord_active >= qp->shm_qp->ord_max) {
+		/* Cannot issue more than ord_max simultaneous RDMA READ
 		 * Requests. */
 		return;
 	} else if (wqe->remote_ep->send_next_psn
@@ -1003,7 +1003,7 @@ do_rdmap_read_request(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 		atomic_store(&qp->shm_qp->conn_state, usiw_qp_error);
 		return;
 	}
-	qp->ird_active++;
+	qp->ord_active++;
 
 	sendmsg = rte_pktmbuf_alloc(qp->dev->tx_ddp_mempool);
 
@@ -1373,8 +1373,8 @@ process_rdma_read_response(struct usiw_qp *qp, struct packet_context *orig)
 			qp_free_send_wqe(qp, read_wqe, true);
 		}
 		rte_spinlock_unlock(&qp->sq.lock);
-		assert(qp->ird_active > 0);
-		qp->ird_active--;
+		assert(qp->ord_active > 0);
+		qp->ord_active--;
 	}
 }	/* process_rdma_read_response */
 

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -1154,13 +1154,16 @@ process_send(struct usiw_qp *qp, struct packet_context *orig)
 		} else if (serial_less_32(msn, ee->expected_recv_msn)) {
 			/* This is a duplicate of a previously received
 			 * message */
+			RTE_LOG(INFO, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Received msn=%" PRIu32 " but expected msn=%" PRIu32 "\n",
+					qp->shm_qp->dev_id, qp->shm_qp->qp_id,
+					msn, ee->expected_recv_msn);
 			do_rdmap_terminate(qp, orig,
 					ddp_error_untagged_invalid_msn);
 			return;
 		} else {
 			/* else, we received this message out of order */
 			assert(serial_greater_32(msn, ee->expected_recv_msn));
-			RTE_LOG(DEBUG, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Received msn=%" PRIu32 " but expected msn=%" PRIu32 "\n",
+			RTE_LOG(INFO, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Received msn=%" PRIu32 " but expected msn=%" PRIu32 "\n",
 					qp->shm_qp->dev_id, qp->shm_qp->qp_id,
 					msn, ee->expected_recv_msn);
 		}
@@ -1276,7 +1279,7 @@ process_rdma_read_request(struct usiw_qp *qp, struct packet_context *orig)
 
 	msn = rte_be_to_cpu_32(rdmap->untagged.msn);
 	if (msn != orig->src_ep->expected_read_msn) {
-		RTE_LOG(DEBUG, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> RDMA READ failure: expected MSN %" PRIu32 " received %" PRIu32 "\n",
+		RTE_LOG(INFO, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> RDMA READ failure: expected MSN %" PRIu32 " received %" PRIu32 "\n",
 				qp->shm_qp->dev_id, qp->shm_qp->qp_id,
 				orig->src_ep->expected_read_msn, msn);
 		do_rdmap_terminate(qp, orig, ddp_error_untagged_invalid_msn);
@@ -1790,7 +1793,7 @@ process_data_packet(struct usiw_qp *qp, struct rte_mbuf *mbuf)
 		/* We detected a sequence number gap.  Try to build a
 		 * contiguous range so we can send a SACK to lower the number
 		 * of retransmissions. */
-		RTE_LOG(DEBUG, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> receive psn %" PRIu32 "; next expected psn %" PRIu32 "\n",
+		RTE_LOG(INFO, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> receive psn %" PRIu32 "; next expected psn %" PRIu32 "\n",
 				qp->shm_qp->dev_id, qp->shm_qp->qp_id,
 				ctx.psn,
 				ctx.src_ep->recv_ack_psn);

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -1980,8 +1980,7 @@ progress_qp(struct usiw_qp *qp)
 		}
 		assert(send_wqe->state != SEND_WQE_INIT);
 		progress_send_wqe(qp, send_wqe);
-		if (send_wqe->state == SEND_WQE_TRANSFER
-				|| send_wqe->opcode == usiw_wr_write) {
+		if (send_wqe->state == SEND_WQE_TRANSFER) {
 			scount++;
 		}
 	}

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -2045,7 +2045,9 @@ usiw_do_destroy_qp(struct usiw_qp *qp)
 	msg.hdr.qp_id = rte_cpu_to_be_16(qp->shm_qp->qp_id);
 	msg.ptr = rte_cpu_to_be_64((uintptr_t)qp->shm_qp);
 	send(qp->dev->urdmad_fd, &msg, sizeof(msg), 0);
-	//free(qp);
+	free(qp->stats.recv_count_histo);
+	free(qp->txq);
+	free(qp);
 } /* usiw_do_destroy_qp */
 
 

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -240,6 +240,7 @@ struct read_response_state {
 	uint32_t msg_size;
 	uint32_t sink_stag; /* network byte order */
 	uint64_t sink_offset; /* host byte order */
+	bool active;
 	struct ee_state *sink_ep;
 	TAILQ_ENTRY(read_response_state) qp_entry;
 };
@@ -280,8 +281,7 @@ struct usiw_qp {
 	struct usiw_recv_wqe_queue rq0;
 
 	struct read_response_state *readresp_store;
-	struct read_response_state_tailq_head readresp_active;
-	struct read_response_state_tailq_head readresp_empty;
+	uint32_t readresp_head_msn;
 	uint8_t ord_active;
 
 	struct usiw_cq *recv_cq;

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -63,7 +63,6 @@
 #include "verbs.h"
 
 #define TX_BURST_SIZE 8
-#define RX_BURST_SIZE 32
 #define DPDKV_MAX_QP 64
 #define MAX_ARP_ENTRIES 32
 #define MAX_RECV_WR 1023

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -106,7 +106,7 @@ struct usiw_recv_wqe {
 	struct ee_state *remote_ep;
 	TAILQ_ENTRY(usiw_recv_wqe) active;
 	uint32_t msn;
-	uint32_t index;
+	bool complete;
 	size_t total_request_size;
 	size_t recv_size;
 	size_t input_size;
@@ -191,6 +191,7 @@ struct usiw_recv_wqe_queue {
 	struct rte_ring *ring;
 	struct rte_ring *free_ring;
 	TAILQ_HEAD(usiw_recv_wqe_active_head, usiw_recv_wqe) active_head;
+	uint32_t next_msn;
 	char *storage;
 	int max_wr;
 	int max_sge;
@@ -208,7 +209,6 @@ enum {
 };
 
 struct ee_state {
-	uint32_t expected_recv_msn;
 	uint32_t expected_read_msn;
 	uint32_t expected_ack_msn;
 	uint32_t next_send_msn;

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -62,7 +62,6 @@
 #include "list.h"
 #include "verbs.h"
 
-#define TX_BURST_SIZE 8
 #define MAX_RECV_WR 1023
 #define MAX_SEND_WR 1023
 #define DPDK_VERBS_IOV_LEN_MAX 32
@@ -266,11 +265,11 @@ struct usiw_qp {
 	struct usiw_cq *send_cq;
 
 	/* txq_end points one entry beyond the last entry in the table
-	 * the table is full when txq_end == txq + TX_BURST_SIZE
+	 * the table is full when txq_end == txq + tx_burst_size
 	 * the burst should be flushed at that point
 	 */
 	struct rte_mbuf **txq_end;
-	struct rte_mbuf *txq[TX_BURST_SIZE];
+	struct rte_mbuf **txq;
 
 	struct usiw_send_wqe_queue sq;
 

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -63,7 +63,6 @@
 #include "verbs.h"
 
 #define TX_BURST_SIZE 8
-#define DPDKV_MAX_QP 64
 #define MAX_ARP_ENTRIES 32
 #define MAX_RECV_WR 1023
 #define MAX_SEND_WR 1023
@@ -368,6 +367,8 @@ struct usiw_driver {
 	struct rte_ring *new_ctxs;
 	int urdmad_fd;
 	uint32_t lcore_mask[RTE_MAX_LCORE / 32];
+	uint16_t device_count;
+	uint16_t *max_qp;
 };
 
 /** Starts the progress thread. */

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -63,7 +63,6 @@
 #include "verbs.h"
 
 #define TX_BURST_SIZE 8
-#define MAX_ARP_ENTRIES 32
 #define MAX_RECV_WR 1023
 #define MAX_SEND_WR 1023
 #define DPDK_VERBS_IOV_LEN_MAX 32

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -282,7 +282,7 @@ struct usiw_qp {
 	struct read_response_state *readresp_store;
 	struct read_response_state_tailq_head readresp_active;
 	struct read_response_state_tailq_head readresp_empty;
-	uint8_t ird_active;
+	uint8_t ord_active;
 
 	struct usiw_cq *recv_cq;
 	struct usiw_mr_table *pd;

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -787,6 +787,7 @@ usiw_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr)
 	struct usiw_context *ctx;
 	struct ee_state *ee;
 	struct usiw_qp *qp;
+	size_t sz;
 	int retval;
 
 	if ((qp_init_attr->qp_type != IBV_QPT_UD
@@ -815,8 +816,10 @@ usiw_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr)
 	if (!qp_init_attr->cap.max_recv_sge) {
 		qp_init_attr->cap.max_recv_sge = 3;
 	}
-	if (qp_init_attr->cap.max_inline_data > sizeof(struct iovec)
-					* qp_init_attr->cap.max_send_sge) {
+	sz = qp_init_attr->cap.max_send_sge * sizeof(struct iovec);
+	if (!qp_init_attr->cap.max_inline_data < sz) {
+		qp_init_attr->cap.max_inline_data = sz;
+	} else if (qp_init_attr->cap.max_inline_data > sz) {
 		qp_init_attr->cap.max_send_sge
 			= (qp_init_attr->cap.max_inline_data - 1)
 			/ sizeof(struct iovec) + 1;

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -850,12 +850,6 @@ usiw_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr)
 	atomic_store(&qp->shm_qp->conn_state, usiw_qp_unbound);
 	qp->ctx = ctx;
 	qp->dev = ctx->dev;
-	qp->stats.recv_max_burst_size = RX_BURST_SIZE;
-	qp->stats.recv_count_histo = calloc(qp->stats.recv_max_burst_size + 1,
-			sizeof(*qp->stats.recv_count_histo));
-	if (!qp->stats.recv_count_histo) {
-		goto free_kernel_qp;
-	}
 
 	qp->send_cq = container_of(qp_init_attr->send_cq,
 			struct usiw_cq, ib_cq);

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -326,6 +326,7 @@ static int
 usiw_query_device(struct ibv_context *context,
 		struct ibv_device_attr *device_attr)
 {
+	struct usiw_context *ourctx;
 	struct ibv_query_device cmd;
 	__attribute__((unused)) uint64_t raw_fw_ver;
 	int ret;
@@ -337,6 +338,7 @@ usiw_query_device(struct ibv_context *context,
 	ret = ibv_cmd_query_device(context, device_attr,
 			&raw_fw_ver, &cmd, sizeof(cmd));
 
+	ourctx = usiw_get_context(context);
 	strncpy(device_attr->fw_ver, PACKAGE_VERSION,
 		sizeof(device_attr->fw_ver));
 	device_attr->max_mr_size = MAX_MR_SIZE;
@@ -344,7 +346,7 @@ usiw_query_device(struct ibv_context *context,
 	device_attr->vendor_id = URDMA_VENDOR_ID;
 	device_attr->vendor_part_id = URDMA_VENDOR_PART_ID;
 	device_attr->hw_ver = 0;
-	device_attr->max_qp = DPDKV_MAX_QP - 1;
+	device_attr->max_qp = ourctx->dev->max_qp;
 	device_attr->max_qp_wr = RTE_MIN(MAX_SEND_WR, MAX_RECV_WR);
 	device_attr->device_cap_flags = 0;
 	device_attr->max_sge = DPDK_VERBS_IOV_LEN_MAX;

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -145,6 +145,7 @@ urdma_accl_post_recvv(struct ibv_qp *ib_qp, const struct iovec *iov, size_t iov_
 	wqe->msn = 0;
 	wqe->recv_size = 0;
 	wqe->input_size = 0;
+	wqe->complete = false;
 	x = rte_ring_enqueue(qp->rq0.ring, wqe);
 	assert(x == 0);
 
@@ -891,7 +892,6 @@ usiw_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr)
 	qp->ord_active = 0;
 
 	ee = &qp->remote_ep;
-	ee->expected_recv_msn = 1;
 	ee->expected_read_msn = 1;
 	ee->expected_ack_msn = 1;
 	ee->next_send_msn = 1;
@@ -1221,6 +1221,7 @@ usiw_post_recv(struct ibv_qp *ib_qp, struct ibv_recv_wr *wr,
 		wqe->msn = 0;
 		wqe->recv_size = 0;
 		wqe->input_size = 0;
+		wqe->complete = false;
 		x = rte_ring_enqueue(qp->rq0.ring, wqe);
 		assert(x == 0);
 	}

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -369,7 +369,7 @@ usiw_query_device(struct ibv_context *context,
 	device_attr->max_mcast_grp = 0;
 	device_attr->max_mcast_qp_attach = 0;
 	device_attr->max_total_mcast_qp_attach = 0;
-	device_attr->max_ah = MAX_ARP_ENTRIES;
+	device_attr->max_ah = 0;
 	device_attr->max_fmr = 0;
 	device_attr->max_srq = 0;
 	device_attr->max_pkeys = 0;

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -884,8 +884,7 @@ usiw_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr)
 	}
 
 	qp->readresp_store = NULL;
-	TAILQ_INIT(&qp->readresp_active);
-	TAILQ_INIT(&qp->readresp_empty);
+	qp->readresp_head_msn = 1;
 	qp->ord_active = 0;
 
 	ee = &qp->remote_ep;

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -886,7 +886,7 @@ usiw_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr)
 	qp->readresp_store = NULL;
 	TAILQ_INIT(&qp->readresp_active);
 	TAILQ_INIT(&qp->readresp_empty);
-	qp->ird_active = 0;
+	qp->ord_active = 0;
 
 	ee = &qp->remote_ep;
 	ee->expected_recv_msn = 1;

--- a/src/urdmad/interface.h
+++ b/src/urdmad/interface.h
@@ -71,6 +71,7 @@ struct usiw_port {
 	uint16_t rx_desc_count;
 	uint16_t tx_desc_count;
 	uint16_t rx_burst_size;
+	uint16_t tx_burst_size;
 	uint16_t max_qp;
 	struct urdmad_qp_head avail_qp;
 	struct urdmad_qp *qp;

--- a/src/urdmad/interface.h
+++ b/src/urdmad/interface.h
@@ -48,9 +48,6 @@
 
 #define PENDING_DATAGRAM_INFO_SIZE 64
 #define RX_BURST_SIZE 32
-#define RX_DESC_COUNT_MAX 1024
-#define TX_DESC_COUNT_MAX 1024
-#define URDMA_MAX_QP 31
 
 #ifndef container_of
 #define container_of(ptr, type, field) \

--- a/src/urdmad/interface.h
+++ b/src/urdmad/interface.h
@@ -47,7 +47,6 @@
 #include <rte_spinlock.h>
 
 #define PENDING_DATAGRAM_INFO_SIZE 64
-#define RX_BURST_SIZE 32
 
 #ifndef container_of
 #define container_of(ptr, type, field) \
@@ -71,6 +70,7 @@ struct usiw_port {
 
 	uint16_t rx_desc_count;
 	uint16_t tx_desc_count;
+	uint16_t rx_burst_size;
 	uint16_t max_qp;
 	struct urdmad_qp_head avail_qp;
 	struct urdmad_qp *qp;

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -267,6 +267,10 @@ handle_qp_connected_event(struct urdma_qp_connected_event *event, size_t count)
 	if (qp->rx_burst_size > qp->rx_desc_count + 1) {
 		qp->rx_burst_size = qp->rx_desc_count + 1;
 	}
+	qp->tx_burst_size = dev->tx_burst_size;
+	if (qp->tx_burst_size > dev->tx_desc_count) {
+		qp->tx_burst_size = dev->tx_desc_count;
+	}
 	memcpy(&qp->remote_ether_addr, event->dst_ether, ETHER_ADDR_LEN);
 	if (dev->flags & port_fdir) {
 		memset(&fdirf, 0, sizeof(fdirf));
@@ -785,10 +789,12 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 		iface->tx_desc_count = port_config->tx_desc_count;
 	}
 	iface->rx_burst_size = port_config->rx_burst_size;
+	iface->tx_burst_size = port_config->tx_burst_size;
 	fprintf(stderr,
-		"port %" PRIu16 " tx_desc_count %" PRIu16 " rx_desc_count %" PRIu16 " rx_burst_size %" PRIu16 "\n",
+		"port %" PRIu16 " tx_desc_count %" PRIu16 " rx_desc_count %" PRIu16 " rx_burst_size %" PRIu16 " tx_burst_size %" PRIu16 "\n",
 		iface->portid, iface->tx_desc_count,
-		iface->rx_desc_count, iface->rx_burst_size);
+		iface->rx_desc_count, iface->rx_burst_size,
+		iface->tx_burst_size);
 
 	LIST_INIT(&iface->avail_qp);
 

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -724,6 +724,7 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 	iface->flags = 0;
 	port_conf.rxmode.max_rx_pkt_len
 			= port_config->mtu + ETHER_HDR_LEN + ETHER_CRC_LEN;
+	port_conf.rxmode.jumbo_frame = !!(port_config->mtu > 1500);
 	if ((iface->dev_info.tx_offload_capa & tx_checksum_offloads)
 			== tx_checksum_offloads) {
 		iface->flags |= port_checksum_offload;

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -779,22 +779,42 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 
 	/* TODO: Auto-tuning of rx_desc_count and tx_desc_count */
 	if (port_config->rx_desc_count == UINT_MAX) {
-		iface->rx_desc_count = iface->dev_info.rx_desc_lim.nb_max;
-	} else if (iface->rx_desc_count > iface->dev_info.rx_desc_lim.nb_max) {
+		iface->rx_desc_count = iface->dev_info.rx_desc_lim.nb_min;
+	} else if (port_config->rx_desc_count > iface->dev_info.rx_desc_lim.nb_max) {
 		rte_exit(EXIT_FAILURE,
 			 "port %" PRIu16 " configured rx_desc_count %" PRIu16 " > rx_desc_lim.nb_max %" PRIu16 "\n",
 			 iface->portid, iface->rx_desc_count,
 			 iface->dev_info.rx_desc_lim.nb_max);
+	} else if (port_config->rx_desc_count < iface->dev_info.rx_desc_lim.nb_min) {
+		rte_exit(EXIT_FAILURE,
+			 "port %" PRIu16 " configured rx_desc_count %" PRIu16 " < rx_desc_lim.nb_min %" PRIu16 "\n",
+			 iface->portid, iface->rx_desc_count,
+			 iface->dev_info.rx_desc_lim.nb_min);
+	} else if (port_config->rx_desc_count % iface->dev_info.rx_desc_lim.nb_align) {
+		rte_exit(EXIT_FAILURE,
+			 "port %" PRIu16 " configured rx_desc_count %" PRIu16 " does not match alignment %" PRIu16 "\n",
+			 iface->portid, iface->rx_desc_count,
+			 iface->dev_info.rx_desc_lim.nb_align);
 	} else {
 		iface->rx_desc_count = port_config->rx_desc_count;
 	}
 	if (port_config->tx_desc_count == UINT_MAX) {
-		iface->tx_desc_count = iface->dev_info.tx_desc_lim.nb_max;
-	} else if (iface->tx_desc_count > iface->dev_info.tx_desc_lim.nb_max) {
+		iface->tx_desc_count = iface->dev_info.tx_desc_lim.nb_min;
+	} else if (port_config->tx_desc_count > iface->dev_info.tx_desc_lim.nb_max) {
 		rte_exit(EXIT_FAILURE,
 			 "port %" PRIu16 " configured tx_desc_count %" PRIu16 " > tx_desc_lim.nb_max %" PRIu16 "\n",
 			 iface->portid, iface->tx_desc_count,
 			 iface->dev_info.tx_desc_lim.nb_max);
+	} else if (port_config->tx_desc_count < iface->dev_info.tx_desc_lim.nb_min) {
+		rte_exit(EXIT_FAILURE,
+			 "port %" PRIu16 " configured tx_desc_count %" PRIu16 " < tx_desc_lim.nb_min %" PRIu16 "\n",
+			 iface->portid, iface->tx_desc_count,
+			 iface->dev_info.tx_desc_lim.nb_min);
+	} else if (port_config->tx_desc_count % iface->dev_info.tx_desc_lim.nb_align) {
+		rte_exit(EXIT_FAILURE,
+			 "port %" PRIu16 " configured tx_desc_count %" PRIu16 " does not match alignment %" PRIu16 "\n",
+			 iface->portid, iface->tx_desc_count,
+			 iface->dev_info.tx_desc_lim.nb_align);
 	} else {
 		iface->tx_desc_count = port_config->tx_desc_count;
 	}

--- a/src/util/config_file.c
+++ b/src/util/config_file.c
@@ -198,6 +198,11 @@ urdma__config_file_get_ports(struct usiw_config *config,
 					&(*port_config)[i].tx_desc_count) < 0) {
 			return -EINVAL;
 		}
+		if (get_uint_value(port, i, "tx_burst_size",
+					1, (*port_config)[i].tx_desc_count, 8,
+					&(*port_config)[i].tx_burst_size) < 0) {
+			return -EINVAL;
+		}
 	}
 
 	return port_count;

--- a/src/util/config_file.c
+++ b/src/util/config_file.c
@@ -186,6 +186,13 @@ urdma__config_file_get_ports(struct usiw_config *config,
 					&(*port_config)[i].rx_desc_count) < 0) {
 			return -EINVAL;
 		}
+		if (get_uint_value(port, i, "rx_burst_size",
+					1, (*port_config)[i].rx_desc_count,
+					((*port_config)[i].rx_desc_count > 32)
+					? (*port_config)[i].rx_desc_count : 32,
+					&(*port_config)[i].rx_burst_size) < 0) {
+			return -EINVAL;
+		}
 		if (get_uint_value(port, i, "tx_desc_count",
 					1, UINT_MAX, UINT_MAX,
 					&(*port_config)[i].tx_desc_count) < 0) {

--- a/src/util/config_file.c
+++ b/src/util/config_file.c
@@ -59,11 +59,70 @@
 #define DEFAULT_MTU 1500
 #define JUMBO_MTU 9000
 
+
+static int
+get_int_value(struct json_object *parent, int index,
+		const char *name, int min, int max, int def, int *val)
+{
+	struct json_object *obj;
+
+	if (json_object_object_get_ex(parent, name, &obj)) {
+		if (!json_object_is_type(obj, json_type_int)
+				&& !json_object_is_type(obj,
+							json_type_string)) {
+			fprintf(stderr,
+				"Configuration error: port %d field \"%s\" is not integer\n",
+				index, name);
+			return -EINVAL;
+		}
+		*val = json_object_get_int(obj);
+		if (*val < min || *val > max) {
+			fprintf(stderr, "Configuration error: port %d field \"%s\" (%u) must be in range [%u, %u]\n",
+					index, name, *val, min, max);
+			return -EINVAL;
+		}
+	} else {
+		*val = def;
+	}
+
+	return 0;
+} /* get_int_value */
+
+
+static int
+get_uint_value(struct json_object *parent, int index,
+		const char *name, unsigned int min, unsigned int max,
+		unsigned int def, unsigned int *val)
+{
+	struct json_object *obj;
+
+	if (json_object_object_get_ex(parent, name, &obj)) {
+		if (!json_object_is_type(obj, json_type_int)
+				&& !json_object_is_type(obj,
+							json_type_string)) {
+			fprintf(stderr,
+				"Configuration error: port %d field \"%s\" is not integer\n",
+				index, name);
+			return -EINVAL;
+		}
+		*val = json_object_get_int(obj);
+		if (*val < min || *val > max) {
+			fprintf(stderr, "Configuration error: port %d field \"%s\" (%u) must be in range [%u, %u]\n",
+					index, name, *val, min, max);
+			return -EINVAL;
+		}
+	} else {
+		*val = def;
+	}
+
+	return 0;
+} /* get_uint_value */
+
 int
 urdma__config_file_get_ports(struct usiw_config *config,
 			     struct usiw_port_config **port_config)
 {
-	struct json_object *ports, *port, *ipv4, *mtu;
+	struct json_object *ports, *port, *obj;
 	int port_count, i;
 
 	if (!json_object_object_get_ex(config->root, "ports", &ports)) {
@@ -88,26 +147,26 @@ urdma__config_file_get_ports(struct usiw_config *config,
 					i);
 			return -EINVAL;
 		}
-		if (!json_object_object_get_ex(port, "ipv4_address", &ipv4)) {
+		if (!json_object_object_get_ex(port, "ipv4_address", &obj)) {
 			fprintf(stderr, "Configuration error: port has no \"ipv4_address\" field\n");
 			return -EINVAL;
 		}
-		if (!json_object_is_type(ipv4, json_type_string)) {
+		if (!json_object_is_type(obj, json_type_string)) {
 			fprintf(stderr, "Configuration error: ipv4_address is not string\n");
 			return -EINVAL;
 		}
 		strncpy((*port_config)[i].ipv4_address,
-				json_object_get_string(ipv4),
+				json_object_get_string(obj),
 				ipv4_addr_len_max);
 
-		if (json_object_object_get_ex(port, "mtu", &mtu)) {
-			if (!json_object_is_type(mtu, json_type_int)
-					&& !json_object_is_type(mtu,
+		if (json_object_object_get_ex(port, "mtu", &obj)) {
+			if (!json_object_is_type(obj, json_type_int)
+					&& !json_object_is_type(obj,
 						json_type_string)) {
 				fprintf(stderr, "Configuration error: port %d mtu is not integer\n", i);
 				return -EINVAL;
 			}
-			(*port_config)[i].mtu = json_object_get_int(mtu);
+			(*port_config)[i].mtu = json_object_get_int(obj);
 			if ((*port_config)[i].mtu != DEFAULT_MTU
 					&& (*port_config)[i].mtu != JUMBO_MTU) {
 				fprintf(stderr, "Configuration error: port %d mtu %u invalid; expected 1500 or 9000\n",
@@ -116,6 +175,21 @@ urdma__config_file_get_ports(struct usiw_config *config,
 			}
 		} else {
 			(*port_config)[i].mtu = DEFAULT_MTU;
+		}
+
+		if (get_int_value(port, i, "max_qp", 1, UINT16_MAX, -1,
+				&(*port_config)[i].max_qp) < 0) {
+			return -EINVAL;
+		}
+		if (get_uint_value(port, i, "rx_desc_count",
+					1, UINT_MAX, UINT_MAX,
+					&(*port_config)[i].rx_desc_count) < 0) {
+			return -EINVAL;
+		}
+		if (get_uint_value(port, i, "tx_desc_count",
+					1, UINT_MAX, UINT_MAX,
+					&(*port_config)[i].tx_desc_count) < 0) {
+			return -EINVAL;
 		}
 	}
 

--- a/src/util/config_file.h
+++ b/src/util/config_file.h
@@ -45,6 +45,9 @@ struct json_object;
 
 struct usiw_port_config {
 	unsigned int mtu;
+	unsigned int rx_desc_count;
+	unsigned int tx_desc_count;
+	int max_qp;
 	char ipv4_address[ipv4_addr_len_max];
 };
 

--- a/src/util/config_file.h
+++ b/src/util/config_file.h
@@ -47,6 +47,7 @@ struct usiw_port_config {
 	unsigned int mtu;
 	unsigned int rx_desc_count;
 	unsigned int tx_desc_count;
+	unsigned int rx_burst_size;
 	int max_qp;
 	char ipv4_address[ipv4_addr_len_max];
 };

--- a/src/util/config_file.h
+++ b/src/util/config_file.h
@@ -48,6 +48,7 @@ struct usiw_port_config {
 	unsigned int rx_desc_count;
 	unsigned int tx_desc_count;
 	unsigned int rx_burst_size;
+	unsigned int tx_burst_size;
 	int max_qp;
 	char ipv4_address[ipv4_addr_len_max];
 };


### PR DESCRIPTION
This PR adds the following changes:
* Tuning parameters for queue pair, descriptor, and burst size limits
* Bug fixes for IRD/ORD negotiation
* Allow more than 1 outstanding RDMA WRITE, as RFC 5040 allows placing tagged DDP segments out of order
* Bug fixes for out-of-order data segments
* Other small bug fixes