### PR TITLE
Next batch of updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,15 @@ if test ! -f ${KERNELDIR}/Makefile; then
 	AC_MSG_ERROR([urdma requires a kernel source tree.  Install kernel-devel or equivalent])
 fi
 
+AC_ARG_ENABLE([debug], [AS_HELP_STRING([--enable-debug],
+		[Enable debug prints by default])],
+	      [case ${enableval} in
+	       yes|no) WANT_DEBUG=${enableval} ;;
+	       *) AC_MSG_ERROR([Invalid value ${enableval} for --enable-debug]) ;;
+	       esac],
+	      [WANT_DEBUG=no])
+AC_SUBST([WANT_DEBUG])
+
 AC_ARG_ENABLE([werror], [AS_HELP_STRING([--enable-werror],
 	      [Treat compiler warnings as errors])],
 	      [case ${enable_werror} in
@@ -251,6 +260,7 @@ Using libdir: ${libdir}
 Using includedir: ${includedir}
 Using bindir: ${bindir}
 Using C compiler: ${CC} ${EXTRA_CFLAGS} ${CFLAGS} ${CPPFLAGS}
+Enable debug: ${WANT_DEBUG}
 
 You can now run 'make' to build and 'make install' to install.
 -----------------------------------------------------------------------

--- a/include/urdmad_private.h
+++ b/include/urdmad_private.h
@@ -98,6 +98,8 @@ struct urdmad_qp {
 
 	uint16_t rx_desc_count;
 		/**< Hardware receive descriptors on this RX queue. */
+	uint16_t tx_desc_count;
+		/**< Hardware receive descriptors on this TX queue. */
 	uint16_t rx_burst_size;
 		/**< Size of array passed to rte_eth_rx_burst(). */
 	uint16_t tx_burst_size;

--- a/src/kmod/Kbuild
+++ b/src/kmod/Kbuild
@@ -37,6 +37,8 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+ccflags-y += -g -DDEBUG -DPACKAGE_VERSION=$(PACKAGE_VERSION)
+
 obj-m += urdma.o
 
 urdma-objs := ae.o cm.o debug.o main.o mem.o obj.o qp.o verbs.o

--- a/src/kmod/Kbuild
+++ b/src/kmod/Kbuild
@@ -37,7 +37,11 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-ccflags-y += -g -DDEBUG -DPACKAGE_VERSION=$(PACKAGE_VERSION)
+# Define to y to enable debug messages by default
+CONFIG_URDMA_DEBUG ?= n
+
+ccflags-y += -g -DPACKAGE_VERSION=$(PACKAGE_VERSION)
+ccflags-$(CONFIG_URDMA_DEBUG) += -DDEBUG
 
 obj-m += urdma.o
 

--- a/src/kmod/Makefile.in
+++ b/src/kmod/Makefile.in
@@ -45,7 +45,7 @@ all:
 	for i in $(SOURCES); do if [ ! -e $${i} ]; then ln -s @srcdir@/$${i} $${i}; fi; done
 	if [ ! -e urdma_kabi.h ]; then ln -s @top_srcdir@/include/urdma_kabi.h .; fi
 	if [ ! -e proto_trp.h ]; then ln -s @top_srcdir@/include/proto_trp.h .; fi
-	make -C @KERNELDIR@ M=`pwd` top_srcdir=$(realpath @top_srcdir@) modules EXTRA_CFLAGS="-g -DDEBUG -DPACKAGE_VERSION='\"@PACKAGE_VERSION@\"'"
+	make -C @KERNELDIR@ M=`pwd` top_srcdir=$(realpath @top_srcdir@) PACKAGE_VERSION='\"@PACKAGE_VERSION@\"' modules
 
 Makefile: @srcdir@/Makefile.in
 	cd @top_builddir@; ./config.status

--- a/src/kmod/Makefile.in
+++ b/src/kmod/Makefile.in
@@ -1,4 +1,4 @@
-# Makefile.in
+# @configure_input@
 
 # Userspace Software iWARP library for DPDK
 #
@@ -39,6 +39,10 @@
 
 SOURCES = ae.c backports.h cm.c cm.h debug.c debug.h main.c mem.c \
 	  obj.c obj.h qp.c urdma.h verbs.c verbs.h Kbuild
+
+ifeq ($(WANT_DEBUG),yes)
+export CONFIG_URDMA_DEBUG = y
+endif
 
 .PHONY: all
 all:

--- a/src/kmod/backports.h
+++ b/src/kmod/backports.h
@@ -64,6 +64,12 @@
 #define HAVE_IB_GET_PORT_IMMUTABLE 1
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
+/* Introduced in Linux commit 036b10635739f and first appeared in
+ * Linux 4.3-rc1. */
+#define HAVE_IB_DISASSOCIATE_CONTEXT 1
+#endif
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
 /* Removed in Linux commit b7d3e0a94fe1, which first appeared in
  * Linux 4.5-rc1. */

--- a/src/kmod/cm.c
+++ b/src/kmod/cm.c
@@ -1316,6 +1316,9 @@ accept_error:
 	siw_cep_put(cep);
 
 out:
+	/* Decrement the refcount that was incremented when this was added to
+	 * the urdmad chardev lists */
+	siw_cep_put(cep);
 	return rv;
 }
 

--- a/src/kmod/cm.c
+++ b/src/kmod/cm.c
@@ -122,7 +122,6 @@ static struct siw_cep *siw_cep_alloc(struct siw_dev  *sdev)
 	if (cep) {
 		unsigned long flags;
 
-		INIT_LIST_HEAD(&cep->disconnect_entry);
 		INIT_LIST_HEAD(&cep->rtr_wait_entry);
 		INIT_LIST_HEAD(&cep->established_entry);
 		INIT_LIST_HEAD(&cep->listenq);

--- a/src/kmod/cm.h
+++ b/src/kmod/cm.h
@@ -92,10 +92,6 @@ struct siw_cep {
 	 */
 	struct list_head	listenq;
 
-	/* The list of connections that have been disconnected but we have not
-	 * yet notified userspace. */
-	struct list_head	disconnect_entry;
-
 	/* The list of connections that have been established but we have not
 	 * yet notified userspace. */
 	struct list_head	established_entry;

--- a/src/kmod/main.c
+++ b/src/kmod/main.c
@@ -126,6 +126,7 @@ static int fetch_dest_hwaddr(struct net_device *netdev,
 	n = dst_neigh_lookup(&rt->dst, &dst_ipv4_addr);
 	if (!n || !(n->nud_state & NUD_VALID)) {
 		rv = -ENODATA;
+		rcu_read_unlock();
 		goto out;
 	}
 	memcpy(dst_hw_addr, n->ha, ETHER_ADDR_LEN);

--- a/src/kmod/main.c
+++ b/src/kmod/main.c
@@ -65,7 +65,7 @@ MODULE_LICENSE("Dual BSD/GPL");
 MODULE_VERSION(PACKAGE_VERSION);
 
 static struct list_head urdma_devlist;
-DEFINE_SPINLOCK(siw_dev_lock);
+static DEFINE_SPINLOCK(siw_dev_lock);
 
 static ssize_t show_sw_version(struct device *dev,
 			       struct device_attribute *attr, char *buf)

--- a/src/kmod/main.c
+++ b/src/kmod/main.c
@@ -339,12 +339,14 @@ static int urdma_chardev_release(struct inode *inodep, struct file *filp)
 		pr_debug("chardev release: remove rtr wait event for cep %p\n",
 				(void *)cep);
 		list_del(pos);
+		siw_cep_put(cep);
 	}
 	list_for_each_safe(pos, next, &file->established_list) {
 		cep = list_entry(pos, struct siw_cep, established_entry);
 		pr_debug("chardev release: remove established event for cep %p\n",
 				(void *)cep);
 		list_del(pos);
+		siw_cep_put(cep);
 	}
 	spin_unlock_bh(&file->lock);
 	module_put(THIS_MODULE);

--- a/src/kmod/main.c
+++ b/src/kmod/main.c
@@ -174,7 +174,7 @@ out:
 /* file->lock MUST be locked before calling this function, but will be unlocked
  * before the function returns. */
 static ssize_t do_read_disconnect_event(struct urdma_chardev_data *file,
-		struct siw_cep *cep, char *buf, size_t count)
+		struct siw_cep *cep, char __user *buf, size_t count)
 	__releases(file->lock)
 {
 	struct urdma_qp_disconnected_event event;
@@ -204,7 +204,7 @@ static ssize_t do_read_disconnect_event(struct urdma_chardev_data *file,
 /* file->lock MUST be locked before calling this function, but will be unlocked
  * before the function returns. */
 static ssize_t do_read_established_event(struct urdma_chardev_data *file,
-		struct siw_cep *cep, char *buf, size_t count)
+		struct siw_cep *cep, char __user *buf, size_t count)
 	__releases(file->lock)
 {
 	struct urdma_qp_connected_event event;
@@ -249,7 +249,7 @@ static ssize_t do_read_established_event(struct urdma_chardev_data *file,
 	return (rv >= 0) ? sizeof(event) : rv;
 } /* do_read_established_event */
 
-static ssize_t urdma_chardev_read(struct file *filp, char *buf,
+static ssize_t urdma_chardev_read(struct file *filp, char __user *buf,
 		size_t count, loff_t *offset)
 {
 	struct urdma_chardev_data *file;
@@ -303,7 +303,7 @@ out:
 	return rv;
 }
 
-static ssize_t urdma_chardev_write(struct file *filp, const char *buf,
+static ssize_t urdma_chardev_write(struct file *filp, const char __user *buf,
 		size_t count, loff_t *offset)
 {
 	struct urdma_chardev_data *file;

--- a/src/kmod/main.c
+++ b/src/kmod/main.c
@@ -635,6 +635,9 @@ static struct siw_dev *siw_device_create(struct net_device *netdev)
 #ifdef HAVE_IB_BIND_MW
 	ofa_dev->bind_mw = NULL;
 #endif
+#ifdef HAVE_IB_DISASSOCIATE_CONTEXT
+	ofa_dev->disassociate_ucontext = urdma_disassociate_ucontext;
+#endif
 
 	ofa_dev->create_srq = siw_create_srq;
 	ofa_dev->modify_srq = siw_modify_srq;

--- a/src/kmod/qp.c
+++ b/src/kmod/qp.c
@@ -140,21 +140,6 @@ notify_established(struct siw_ucontext *ctx, struct siw_qp *qp)
 	}
 }
 
-static void
-notify_disconnected(struct siw_ucontext *ctx, struct siw_qp *qp)
-{
-	struct urdma_chardev_data *file
-		= dev_get_drvdata(ctx->sdev->ofa_dev.dma_device);
-
-	if (file) {
-		qp->cep->urdmad_dev_id = qp->attrs.urdma_devid;
-		qp->cep->urdmad_qp_id = qp->attrs.urdma_qp_id;
-		siw_cep_get(qp->cep);
-		list_add_tail(&qp->cep->disconnect_entry,
-				&file->disconnect_list);
-		wake_up(&file->wait_head);
-	}
-}
 
 static inline struct siw_ucontext *siw_ctx_ofa2siw(struct ib_ucontext *ofa_ctx)
 {
@@ -276,9 +261,6 @@ siw_qp_modify(struct siw_qp *qp, struct siw_qp_attrs *attrs,
 		case SIW_QP_STATE_ERROR:
 			qp->attrs.state = attrs->state;
 			drop_conn = 1;
-			notify_disconnected(
-				siw_ctx_ofa2siw(qp->ofa_qp.uobject->context),
-				qp);
 			break;
 
 		default:

--- a/src/kmod/qp.c
+++ b/src/kmod/qp.c
@@ -148,12 +148,10 @@ static inline struct siw_ucontext *siw_ctx_ofa2siw(struct ib_ucontext *ofa_ctx)
 }
 
 
-/*
- * caller holds qp->state_lock
- */
 int
 siw_qp_modify(struct siw_qp *qp, struct siw_qp_attrs *attrs,
 	      enum siw_qp_attr_mask mask)
+	__must_hold(qp->state_lock)
 {
 	/* Minimum attributes required for INIT/RTR to RTS transition */
 	static const enum siw_qp_attr_mask init_to_rts_mask

--- a/src/kmod/qp.c
+++ b/src/kmod/qp.c
@@ -134,6 +134,7 @@ notify_established(struct siw_ucontext *ctx, struct siw_qp *qp)
 	if (!file) {
 		siw_qp_rtr_fail(qp->cep);
 	} else {
+		siw_cep_get(qp->cep);
 		list_add_tail(&qp->cep->established_entry,
 				&file->established_list);
 		wake_up(&file->wait_head);

--- a/src/kmod/qp.c
+++ b/src/kmod/qp.c
@@ -134,9 +134,11 @@ notify_established(struct siw_ucontext *ctx, struct siw_qp *qp)
 	if (!file) {
 		siw_qp_rtr_fail(qp->cep);
 	} else {
+		spin_lock(&file->lock);
 		siw_cep_get(qp->cep);
 		list_add_tail(&qp->cep->established_entry,
 				&file->established_list);
+		spin_unlock(&file->lock);
 		wake_up(&file->wait_head);
 	}
 }

--- a/src/kmod/urdma.h
+++ b/src/kmod/urdma.h
@@ -80,7 +80,6 @@ struct urdma_chardev_data {
 	struct device		*dev;
 	spinlock_t		lock;
 	struct list_head	established_list;
-	struct list_head	disconnect_list;
 	struct list_head	rtr_wait_list;
 	wait_queue_head_t	wait_head;
 };

--- a/src/kmod/verbs.c
+++ b/src/kmod/verbs.c
@@ -209,6 +209,13 @@ out:
 }
 
 
+/* Empty implementation which allows verbs de-initialization to continue despite
+ * user applications continuing to run. */
+void urdma_disassociate_ucontext(struct ib_ucontext *ctx)
+{
+}
+
+
 struct ib_ucontext *siw_alloc_ucontext(struct ib_device *ofa_dev,
 				       struct ib_udata *udata)
 {

--- a/src/kmod/verbs.h
+++ b/src/kmod/verbs.h
@@ -58,6 +58,7 @@ extern int siw_query_device(struct ib_device *, struct ib_device_attr *,
 			    struct ib_udata *);
 #endif
 
+extern void urdma_disassociate_ucontext(struct ib_ucontext *ctx);
 extern struct ib_ucontext *siw_alloc_ucontext(struct ib_device *,
 					      struct ib_udata *);
 extern int siw_dealloc_ucontext(struct ib_ucontext *);

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -1750,11 +1750,25 @@ process_data_packet(struct usiw_qp *qp, struct rte_mbuf *mbuf)
 	eth_hdr = rte_pktmbuf_mtod(mbuf, struct ether_hdr *);
 
 	ipv4_hdr = (struct ipv4_hdr *)rte_pktmbuf_adj(mbuf, sizeof(*eth_hdr));
-	assert(ipv4_hdr->next_proto_id == IP_HDR_PROTO_UDP);
-	assert(ipv4_hdr->dst_addr == qp->dev->ipv4_addr);
+	if (ipv4_hdr->next_proto_id != IP_HDR_PROTO_UDP) {
+		RTE_LOG(NOTICE, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Drop packet with IPv4 next header %" PRIu8 " not UDP\n",
+			qp->shm_qp->dev_id, qp->shm_qp->qp_id,
+			ipv4_hdr->next_proto_id);
+	}
+	if (ipv4_hdr->dst_addr != qp->dev->ipv4_addr) {
+		RTE_LOG(NOTICE, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Drop packet with IPv4 dst addr %" PRIx32 "; expected %" PRIx32 "\n",
+			qp->shm_qp->dev_id, qp->shm_qp->qp_id,
+			rte_be_to_cpu_32(ipv4_hdr->dst_addr),
+			rte_be_to_cpu_32(qp->dev->ipv4_addr));
+	}
 
 	udp_hdr = (struct udp_hdr *)rte_pktmbuf_adj(mbuf, sizeof(*ipv4_hdr));
-	assert(udp_hdr->dst_port == qp->shm_qp->local_udp_port);
+	if (udp_hdr->dst_port != qp->shm_qp->local_udp_port) {
+		RTE_LOG(NOTICE, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Drop packet with UDP dst port %" PRIu16 "; expected %" PRIu16 "\n",
+			qp->shm_qp->dev_id, qp->shm_qp->qp_id,
+			rte_be_to_cpu_16(udp_hdr->dst_port),
+			rte_be_to_cpu_16(qp->shm_qp->local_udp_port));
+	}
 
 	ctx.src_ep = &qp->remote_ep;
 	if (!ctx.src_ep) {

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -2112,8 +2112,8 @@ start_qp(struct usiw_qp *qp)
 	}
 
 	/* FIXME: Get this from the peer */
-	qp->remote_ep.send_max_psn = qp->shm_qp->rx_desc_count / 2;
-	qp->remote_ep.tx_pending_size = qp->shm_qp->rx_desc_count / 2;
+	qp->remote_ep.send_max_psn = qp->shm_qp->tx_desc_count / 2;
+	qp->remote_ep.tx_pending_size = qp->shm_qp->tx_desc_count / 2;
 	qp->remote_ep.tx_pending = calloc(qp->remote_ep.tx_pending_size,
 			sizeof(*qp->remote_ep.tx_pending));
 	if (!qp->remote_ep.tx_pending) {

--- a/src/urdmad/interface.h
+++ b/src/urdmad/interface.h
@@ -106,6 +106,7 @@ struct usiw_driver {
 
 	struct urdma_fd chardev;
 	struct urdma_fd listen;
+	struct urdma_fd timer;
 	LIST_HEAD(urdma_process_head, urdma_process) processes;
 	int epoll_fd;
 	int port_count;

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -218,6 +218,7 @@ handle_qp_connected_event(struct urdma_qp_connected_event *event, size_t count)
 	struct urdma_qp_rtr_event rtr_event;
 	struct rte_eth_fdir_filter fdirf;
 	struct rte_eth_rxq_info rxq_info;
+	struct rte_eth_txq_info txq_info;
 	struct usiw_port *dev;
 	struct urdmad_qp *qp;
 	ssize_t ret;
@@ -263,6 +264,13 @@ handle_qp_connected_event(struct urdma_qp_connected_event *event, size_t count)
 		qp->rx_desc_count = dev->rx_desc_count;
 	} else {
 		qp->rx_desc_count = rxq_info.nb_desc;
+	}
+	ret = rte_eth_tx_queue_info_get(event->urdmad_dev_id,
+			event->urdmad_qp_id, &txq_info);
+	if (ret < 0) {
+		qp->tx_desc_count = dev->tx_desc_count;
+	} else {
+		qp->tx_desc_count = txq_info.nb_desc;
 	}
 	qp->rx_burst_size = dev->rx_burst_size;
 	if (qp->rx_burst_size > qp->rx_desc_count + 1) {

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -692,7 +692,7 @@ event_loop(void *arg)
 	int portid, ret;
 
 	while (1) {
-		do_poll(50);
+		do_poll(1);
 		for (portid = 0; portid < driver->port_count; ++portid) {
 			port = &driver->ports[portid];
 			ret = rte_kni_handle_request(port->kni);

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -523,6 +523,7 @@ process_data_ready(struct urdma_fd *process_fd)
 err:
 	LIST_REMOVE(process, entry);
 	close(process->fd.fd);
+	free(process);
 } /* process_data_ready */
 
 

--- a/src/util/config_file.c
+++ b/src/util/config_file.c
@@ -371,6 +371,24 @@ urdma__config_file_get_sock_name(struct usiw_config *config)
 	return strdup(json_object_get_string(sock_name));
 } /* urdma__config_file_get_sock_name */
 
+int
+urdma__config_file_get_timer_interval(struct usiw_config *config)
+{
+	struct json_object *interval;
+
+	if (!json_object_object_get_ex(config->root, "stats_timer_interval",
+								&interval)) {
+		return 0;
+	}
+
+	if (!json_object_is_type(interval, json_type_int)) {
+		fprintf(stderr, "Configuration error: \"stats_timer_interval\" field not an integer\n");
+		return 0;
+	}
+
+	return json_object_get_int(interval);
+} /* urdma__config_file_get_timer_interval */
+
 
 /** Parses the given JSON configuration file for the IPv4 addresses to assign
  * to each interface.  An example configuration file looks like:

--- a/src/util/config_file.h
+++ b/src/util/config_file.h
@@ -68,6 +68,9 @@ char *
 urdma__config_file_get_sock_name(struct usiw_config *config);
 
 int
+urdma__config_file_get_timer_interval(struct usiw_config *config);
+
+int
 urdma__config_file_open(struct usiw_config *config);
 
 void

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -39,6 +39,7 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -49,6 +50,20 @@
 #else
 #define NDEBUG_UNUSED
 #endif
+
+#define DO_WARN_ONCE(cond, var, format, ...) ({ \
+	static bool var = false; \
+	if ((cond) && !var) { \
+		var = true; \
+		RTE_LOG(WARNING, USER1, format, __VA_ARGS__); \
+	}; cond; })
+
+#define PASTE(x, y) x##y
+
+/** Prints the given warning message (like fprintf(stderr, format, ...)) if cond
+ * is true, but only once per execution. */
+#define WARN_ONCE(cond, format, ...) \
+	DO_WARN_ONCE(cond, PASTE(xyzwarn_, __LINE__), format, __VA_ARGS__)
 
 int
 parse_ipv4_address(const char *str, uint32_t *address, int *prefix_len);


### PR DESCRIPTION
* Add messages when incoming packets are dropped, either because there are no receive descriptors available or due to CRC errors.
* Fix various errors in kernel modules identified by sparse.  Add sparse locking annotations as needed.
* Fix hang and kernel panic if urdmad is stopped while a verbs application is running.
* Remove unneeded urdmad disconnect event, since urdmad can more reliably just use the QP destroy event (or just the socket going away).
* Other small fixes.