### PR TITLE
Do not use alias STag for RDMA READ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,7 @@ urdma*.tar*
 .libs
 *.la
 *.lo
+*.log
 *.o
+*.o.d
+*.trs

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,8 @@ src_liburdma_liburdma_la_SOURCES = \
 	src/liburdma/interface.h \
 	src/liburdma/verbs.c \
 	src/liburdma/verbs.h \
+	src/util/binheap.c \
+	src/util/binheap.h \
 	src/util/config_file.c \
 	src/util/config_file.h \
 	src/util/list.h \
@@ -140,6 +142,14 @@ src_kvstore_client_kvstore_client_CFLAGS = $(MACHINE_CFLAGS)
 src_kvstore_client_kvstore_client_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/util -I$(srcdir)/src/liburdma $(DPDK_CPPFLAGS)
 src_kvstore_client_kvstore_client_LDFLAGS = $(DPDK_LDFLAGS)
 src_kvstore_client_kvstore_client_LDADD = src/liburdma/liburdma.la $(DPDK_LIBS) -lm
+
+check_PROGRAMS = tests/binheap
+tests_binheap_SOURCES = tests/binheap.c \
+	src/util/binheap.c \
+	src/util/binheap.h
+tests_binheap_CPPFLAGS = -I$(srcdir)/src/util
+
+TESTS = tests/binheap
 
 # Disable the uninstall check since the kernel build system doesn't
 # provide a module uninstall target.

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -7,6 +7,7 @@ depcomp
 install-sh
 ltmain.sh
 missing
+test-driver
 
 # libtool m4 stuff
 libtool.m4

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -1599,6 +1599,7 @@ sweep_unacked_packets(struct usiw_qp *qp, uint64_t now)
 			if (pending->wqe) {
 				do_process_ack(qp, pending->wqe, pending);
 			}
+			pending->psn = UINT32_MAX;
 			rte_pktmbuf_free(sendmsg);
 			*ep->tx_head = NULL;
 			if (++ep->tx_head == end) {

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -59,6 +59,7 @@
 #include <rte_spinlock.h>
 
 #include "urdmad_private.h"
+#include "binheap.h"
 #include "list.h"
 #include "verbs.h"
 
@@ -222,6 +223,7 @@ struct ee_state {
 
 	/* RX TRP state */
 	uint32_t recv_ack_psn;
+	struct binheap *recv_rresp_last_psn;
 
 	uint32_t trp_flags;
 	struct psn_range recv_sack_psn;

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -119,6 +119,7 @@ struct usiw_recv_wqe {
 struct pending_datagram_info {
 	uint64_t next_retransmit;
 	struct usiw_send_wqe *wqe;
+	struct read_response_state *readresp;
 	uint16_t transmit_count;
 	uint16_t ddp_length;
 	uint32_t ddp_raw_cksum;

--- a/src/util/binheap.c
+++ b/src/util/binheap.c
@@ -1,0 +1,147 @@
+/* binheap.c */
+
+/*
+ * Userspace Software iWARP library for DPDK
+ *
+ * Authors: Patrick MacArthur <pmacarth@iol.unh.edu>
+ *
+ * Copyright (c) 2017, University of New Hampshire
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of IBM nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "binheap.h"
+#include <assert.h>
+#include <stdlib.h>
+
+#define SWAP(a, b) { \
+		typeof(a) tmp = a; \
+		a = b; \
+		b = tmp; \
+	}
+
+static int array_min(uint32_t *arr, int i, int j)
+{
+	if (arr[j] < arr[i])
+		return j;
+	else
+		return i;
+}
+
+static void array_swap(uint32_t *arr, int i, int j)
+{
+	SWAP(arr[i], arr[j]);
+}
+
+static void push_down(struct binheap *binheap, int index)
+{
+	int next;
+
+	while (index != 0) {
+		next = (index - 1) / 2;
+		if (binheap->arr[index] < binheap->arr[next]) {
+			array_swap(binheap->arr, index, next);
+			index = next;
+		} else {
+			return;
+		}
+	}
+}
+
+/* Insert element v into binheap while preserving the heap invariant. The
+ * caller is responsible for ensuring the heap remains within its capacity. */
+int binheap_insert(struct binheap *binheap, uint32_t v)
+{
+	assert(binheap->size <= binheap->capacity);
+	if (binheap->size == binheap->capacity) {
+		return -1;
+	}
+	binheap->arr[binheap->size] = v;
+	push_down(binheap, binheap->size++);
+	return 0;
+}	/* binheap_insert */
+
+/* Returns the minimum element of the heap without removing it. */
+int binheap_peek(struct binheap *binheap, uint32_t *v)
+{
+	if (binheap->size == 0) {
+		return -1;
+	}
+
+	*v = binheap->arr[0];
+	return 0;
+}	/* binheap_peek */
+
+/* Removes the minimum element of the heap while preserving the heap
+ * invariant. */
+int binheap_pop(struct binheap *binheap)
+{
+	int index = 0, min;
+	unsigned int left, right;
+
+	if (binheap->size == 0) {
+		return -1;
+	}
+	array_swap(binheap->arr, 0, --binheap->size);
+	while ((left = index * 2 + 1) < binheap->size) {
+		min = array_min(binheap->arr, index, left);
+		right = left + 1;
+		if (right < binheap->size) {
+			min = array_min(binheap->arr, min, right);
+		}
+
+		if (min != index) {
+			array_swap(binheap->arr, index, min);
+			index = min;
+		} else {
+			break;
+		}
+	}
+	return 0;
+}	/* binheap_pop */
+
+/* Creates a binheap with the given capacity >= 0. The binheap will be able to
+ * hold elements of type uint32_t and calling minheap_peek() will return the
+ * minimum element placed into it. */
+struct binheap *
+binheap_new(size_t capacity)
+{
+	struct binheap *heap;
+
+	assert(capacity != 0);
+
+	heap = malloc(sizeof(*heap) + capacity * sizeof(uint32_t));
+	if (heap) {
+		heap->capacity = capacity;
+		heap->size = 0;
+	}
+	return heap;
+}	/* binheap_new */

--- a/src/util/binheap.h
+++ b/src/util/binheap.h
@@ -1,0 +1,65 @@
+/* binheap.h */
+
+/*
+ * Userspace Software iWARP library for DPDK
+ *
+ * Authors: Patrick MacArthur <pmacarth@iol.unh.edu>
+ *
+ * Copyright (c) 2017, University of New Hampshire
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of IBM nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef BINHEAP_H
+#define BINHEAP_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct binheap {
+	size_t size;
+	size_t capacity;
+	uint32_t arr[];
+};
+
+struct binheap *binheap_new(size_t capacity);
+int binheap_insert(struct binheap *binheap, uint32_t v);
+int binheap_peek(struct binheap *binheap, uint32_t *v);
+int binheap_pop(struct binheap *binheap);
+
+static inline bool
+binheap_empty(struct binheap *binheap)
+{
+	return binheap->size == 0;
+}
+
+#endif

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -55,7 +55,7 @@
 	static bool var = false; \
 	if ((cond) && !var) { \
 		var = true; \
-		RTE_LOG(WARNING, USER1, format, __VA_ARGS__); \
+		RTE_LOG(WARNING, USER1, format, ##__VA_ARGS__); \
 	}; cond; })
 
 #define PASTE(x, y) x##y
@@ -63,7 +63,7 @@
 /** Prints the given warning message (like fprintf(stderr, format, ...)) if cond
  * is true, but only once per execution. */
 #define WARN_ONCE(cond, format, ...) \
-	DO_WARN_ONCE(cond, PASTE(xyzwarn_, __LINE__), format, __VA_ARGS__)
+	DO_WARN_ONCE(cond, PASTE(xyzwarn_, __LINE__), format, ##__VA_ARGS__)
 
 int
 parse_ipv4_address(const char *str, uint32_t *address, int *prefix_len);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+binheap

--- a/tests/binheap.c
+++ b/tests/binheap.c
@@ -1,0 +1,218 @@
+/* tests/binheap.c */
+
+/*
+ * Userspace Software iWARP library for DPDK
+ *
+ * Authors: Patrick MacArthur <pmacarth@iol.unh.edu>
+ *
+ * Copyright (c) 2017, University of New Hampshire
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of IBM nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* This file contains tests for our open-coded binary heap code */
+
+#include "binheap.h"
+#include <inttypes.h>
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static const uint32_t magic = 0xA1C;
+
+#define array_size(arr) (sizeof(arr) / sizeof(*arr))
+
+#define FAIL(format, ...) \
+	do { \
+		do_fail("%s: " format, __func__, ##__VA_ARGS__); \
+	} while (0);
+
+static void do_fail(const char *format, ...)
+{
+	va_list va;
+
+	va_start(va, format);
+	vfprintf(stderr, format, va);
+	va_end(va);
+
+	exit(EXIT_FAILURE);
+}
+
+static void test_peek_empty(void)
+{
+	struct binheap *h = binheap_new(1);
+	uint32_t v;
+	int ret;
+
+	v = magic;
+	ret = binheap_peek(h, &v);
+	if (!ret) {
+		FAIL("binheap_peek returned %d on empty heap\n", ret);
+	}
+	if (v != magic) {
+		FAIL("binheap_peek set v=%d expected unchanged\n", v);
+	}
+
+	free(h);
+}
+
+static void test_insert_one(void)
+{
+	struct binheap *h = binheap_new(1);
+	uint32_t v;
+	int ret;
+
+	binheap_insert(h, magic);
+
+	ret = binheap_peek(h, &v);
+	if (ret) {
+		FAIL("binheap_peek returned %d after element inserted\n", ret);
+	}
+	if (v != magic) {
+		FAIL("binheap_peek set v=%d expected %d\n", v, magic);
+	}
+
+	ret = binheap_pop(h);
+	if (ret != 0) {
+		FAIL("binheap_pop returned %d expected 0\n", v);
+	}
+
+	free(h);
+}
+
+static void test_insert_inorder(void)
+{
+	struct binheap *h = binheap_new(8);
+	uint32_t i, v;
+
+	binheap_insert(h, 1);
+	binheap_insert(h, 2);
+	binheap_insert(h, 3);
+	binheap_insert(h, 4);
+	binheap_insert(h, 5);
+	binheap_insert(h, 6);
+	binheap_insert(h, 7);
+	binheap_insert(h, 8);
+
+	for (i = 1; i <= 8; ++i) {
+		binheap_peek(h, &v);
+		if (v != i) {
+			FAIL("binheap_peek set v=%d expected %d\n", v, i);
+		}
+		binheap_pop(h);
+	}
+
+	free(h);
+}
+
+static void test_insert_reverse(void)
+{
+	struct binheap *h = binheap_new(8);
+	uint32_t i, v;
+
+	binheap_insert(h, 8);
+	binheap_insert(h, 7);
+	binheap_insert(h, 6);
+	binheap_insert(h, 5);
+	binheap_insert(h, 4);
+	binheap_insert(h, 3);
+	binheap_insert(h, 2);
+	binheap_insert(h, 1);
+
+	for (i = 1; i <= 8; ++i) {
+		binheap_peek(h, &v);
+		if (v != i) {
+			FAIL("binheap_peek set v=%d expected %d\n", v, i);
+		}
+		binheap_pop(h);
+	}
+
+	free(h);
+}
+
+static void test_pop_left_smallest(void)
+{
+	struct binheap *h = binheap_new(4);
+	uint32_t expected[] = {1, 2, 3};
+	static_assert(array_size(expected) == 3, "array_size");
+	uint32_t v, *p, *end;
+
+	binheap_insert(h, 2);
+	binheap_insert(h, 1);
+	binheap_insert(h, 3);
+
+	for (p = expected, end = expected + array_size(expected);
+			p != end; ++p) {
+		binheap_peek(h, &v);
+		if (v != *p) {
+			FAIL("binheap_peek set v=%" PRIu32 " expected %" PRIu32 "\n",
+					v, *p);
+		}
+		binheap_pop(h);
+	}
+
+	free(h);
+}
+
+static void test_pop_right_smallest(void)
+{
+	struct binheap *h = binheap_new(4);
+	uint32_t expected[] = {1, 2, 3};
+	uint32_t v, *p, *end;
+
+	binheap_insert(h, 2);
+	binheap_insert(h, 3);
+	binheap_insert(h, 1);
+
+	for (p = expected, end = expected + array_size(expected);
+			p != end; ++p) {
+		binheap_peek(h, &v);
+		if (v != *p) {
+			FAIL("binheap_peek set v=%d expected %d\n",
+					v, *p);
+		}
+		binheap_pop(h);
+	}
+
+	free(h);
+}
+
+int main(__attribute__((__unused__)) int argc,
+	 __attribute__((__unused__)) char *argv[])
+{
+	test_peek_empty();
+	test_insert_one();
+	test_insert_inorder();
+	test_insert_reverse();
+	test_pop_left_smallest();
+	test_pop_right_smallest();
+}


### PR DESCRIPTION
This PR replaces the alias STag mechanism previously used by urdma with the standard mechanism of using the STag of the memory region. The requester uses a binary heap to track received RDMA READ response segments and match them with the RDMA READ WQEs. This does not affect wire protocol compatibility since unlike for RDMA WRITE and the RDMA READ target buffer, the RDMA READ local STag is not used or manipulated by the application.