### PR TITLE
Build fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -151,6 +151,8 @@ tests_binheap_CPPFLAGS = -I$(srcdir)/src/util
 
 TESTS = tests/binheap
 
+doc_DATA = doc/urdma-schema.json
+
 # Disable the uninstall check since the kernel build system doesn't
 # provide a module uninstall target.
 distuninstallcheck:

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,7 @@ src_liburdma_liburdma_la_SOURCES = \
 	src/util/list.h \
 	src/util/util.c \
 	src/util/util.h
-src_liburdma_liburdma_la_CFLAGS = $(MACHINE_CFLAGS)
+src_liburdma_liburdma_la_CFLAGS = $(DPDK_CFLAGS)
 src_liburdma_liburdma_la_CPPFLAGS = -Durdma_confdir='"$(sysconfdir)/rdma"' -I$(srcdir)/include -I$(srcdir)/src/util $(LIBNL3_CFLAGS) $(JSON_C_CFLAGS) $(DPDK_CPPFLAGS)
 src_liburdma_liburdma_la_LDFLAGS = -avoid-version \
 	-release @IBV_DEVICE_LIBRARY_EXTENSION@ $(DPDK_LDFLAGS)
@@ -82,7 +82,7 @@ src_urdmad_urdmad_SOURCES = \
 	src/util/config_file.c \
 	src/util/config_file.h \
 	src/util/list.h
-src_urdmad_urdmad_CFLAGS = $(MACHINE_CFLAGS)
+src_urdmad_urdmad_CFLAGS = $(DPDK_CFLAGS)
 src_urdmad_urdmad_CPPFLAGS = -Durdma_confdir='"$(sysconfdir)/rdma"' -I$(srcdir)/include -I$(srcdir)/src/util $(LIBNL3_CFLAGS) $(JSON_C_CFLAGS) $(DPDK_CPPFLAGS)
 src_urdmad_urdmad_LDFLAGS = $(DPDK_LDFLAGS)
 src_urdmad_urdmad_LDADD = $(LIBNL3_LIBS) $(JSON_C_LIBS) $(DPDK_LIBS)
@@ -92,7 +92,7 @@ src_udp_pingpong_udp_pingpong_SOURCES = \
 	src/udp_pingpong/main.c \
 	src/util/util.c \
 	src/util/util.h
-src_udp_pingpong_udp_pingpong_CFLAGS = $(MACHINE_CFLAGS)
+src_udp_pingpong_udp_pingpong_CFLAGS = $(DPDK_CFLAGS)
 src_udp_pingpong_udp_pingpong_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/util $(DPDK_CPPFLAGS)
 src_udp_pingpong_udp_pingpong_LDFLAGS = $(DPDK_LDFLAGS)
 src_udp_pingpong_udp_pingpong_LDADD = $(DPDK_LIBS)
@@ -102,7 +102,7 @@ src_mkkvstore_mkkvstore_SOURCES = \
 	src/mkkvstore/main.c \
 	src/util/util.c \
 	src/util/util.h
-src_mkkvstore_mkkvstore_CFLAGS = $(MACHINE_CFLAGS)
+src_mkkvstore_mkkvstore_CFLAGS = $(DPDK_CFLAGS)
 src_mkkvstore_mkkvstore_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/util $(DPDK_CPPFLAGS)
 src_mkkvstore_mkkvstore_LDFLAGS = $(DPDK_LDFLAGS)
 src_mkkvstore_mkkvstore_LDADD = $(DPDK_LIBS) -lm
@@ -110,7 +110,7 @@ src_mkkvstore_mkkvstore_LDADD = $(DPDK_LIBS) -lm
 bin_PROGRAMS += src/verbs_pingpong/verbs_pingpong
 src_verbs_pingpong_verbs_pingpong_SOURCES = \
 	src/verbs_pingpong/main.c
-src_verbs_pingpong_verbs_pingpong_CFLAGS = $(MACHINE_CFLAGS)
+src_verbs_pingpong_verbs_pingpong_CFLAGS = $(DPDK_CFLAGS)
 src_verbs_pingpong_verbs_pingpong_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/liburdma $(DPDK_CPPFLAGS)
 src_verbs_pingpong_verbs_pingpong_LDFLAGS = $(DPDK_LDFLAGS)
 src_verbs_pingpong_verbs_pingpong_LDADD = $(DPDK_LIBS)
@@ -126,7 +126,7 @@ src_kvstore_server_kvstore_server_SOURCES = \
 	src/kvstore_server/options.h \
 	src/util/util.c \
 	src/util/util.h
-src_kvstore_server_kvstore_server_CFLAGS = $(MACHINE_CFLAGS)
+src_kvstore_server_kvstore_server_CFLAGS = $(DPDK_CFLAGS)
 src_kvstore_server_kvstore_server_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/util -I$(srcdir)/src/liburdma $(DPDK_CPPFLAGS)
 src_kvstore_server_kvstore_server_LDFLAGS = $(DPDK_LDFLAGS)
 src_kvstore_server_kvstore_server_LDADD = src/liburdma/liburdma.la $(DPDK_LIBS) -lm
@@ -138,7 +138,7 @@ src_kvstore_client_kvstore_client_SOURCES = \
 	src/kvstore_client/options.h \
 	src/util/util.c \
 	src/util/util.h
-src_kvstore_client_kvstore_client_CFLAGS = $(MACHINE_CFLAGS)
+src_kvstore_client_kvstore_client_CFLAGS = $(DPDK_CFLAGS)
 src_kvstore_client_kvstore_client_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/util -I$(srcdir)/src/liburdma $(DPDK_CPPFLAGS)
 src_kvstore_client_kvstore_client_LDFLAGS = $(DPDK_LDFLAGS)
 src_kvstore_client_kvstore_client_LDADD = src/liburdma/liburdma.la $(DPDK_LIBS) -lm

--- a/README
+++ b/README
@@ -62,7 +62,7 @@ To run an application with this driver, the KNI and urdma modules must be loaded
 You will need to create a file ${sysconfdir}/rdma/urdma.json that looks
 like this, with appropriate values substituted in:
 
-    { "ports": { "ipv4_address": "10.2.0.100" },
+    { "ports": [ { "ipv4_address": "10.2.0.100" } ],
       "sock_name": "/run/urdma.sock",
       "eal_args": { "log-level": 7 }
     }

--- a/README
+++ b/README
@@ -69,10 +69,14 @@ like this, with appropriate values substituted in:
 
 Finally, the urdmad service must be running:
 
-    $ sudo systemctl start urdmad
+    $ systemctl --user start urdmad
 
 This will cause devices to appear in your "ip link" output, and cause
 uverbs devices to appear in /sys/class/infiniband_verbs.
+
+Or you can manually run urdmad as root; in this case you will need to
+run every verbs application as root to pick up the DPDK configuration
+which cannot be relocated.
 
 Known Issues
 ------------

--- a/README
+++ b/README
@@ -91,6 +91,23 @@ Known Issues
                 --mca btl_openib_receive_queues P,65536,256,192,128 \
 		${mpi_app} ${mpi_app_args}...
 
+ - If running DPDK sample applications succeeds, but running urdmad
+   fails with "Configuration expects N devices but found only 0", the
+   DPDK PMD drivers are probably not being loaded at runtime by default.
+   If this is the case then you will probably need to load them by hand,
+   by adding an argument to urdmad like:
+
+     urdmad -d ${RTE_SDK}/${RTE_TARGET}/lib/libpmd_net_i40e.so.1
+
+   and adding the equivalent to urdma.json:
+
+     "eal_args": { /* ... */, "d": "..." }
+
+   To avoid this, you can set CONFIG_RTE_EAL_PMD_PATH to a directory
+   like /usr/local/lib/dpdk-pmds when building DPDK, and the place the
+   PMD .so files into that directory after DPDK is installed. DPDK will
+   then auto-load all .so files in that directory as PMD libraries.
+
  - There is a potential race condition with completion channels, where a
    completion event can get lost, and thus a thread waiting on
    ibv_get_cq_event() will never wake up, leading to a deadlock.  A cause has

--- a/README
+++ b/README
@@ -63,9 +63,16 @@ You will need to create a file ${sysconfdir}/rdma/urdma.json that looks
 like this, with appropriate values substituted in:
 
     { "ports": [ { "ipv4_address": "10.2.0.100" } ],
-      "sock_name": "/run/urdma.sock",
+      "socket": "/run/urdma.sock",
       "eal_args": { "log-level": 7 }
     }
+
+You can validate your config file against doc/urdma-schema.json using
+any JSON schema validator; python-jsonschema which comes with Ubuntu is
+one possibility. Note that this schema file is stricter than what is
+actually allowed at runtime; at runtime, additional properties are
+simply ignored but the schema file does not allow them; this is to make
+typos more obvious.
 
 Finally, the urdmad service must be running:
 

--- a/config/ax_compare_version.m4
+++ b/config/ax_compare_version.m4
@@ -1,0 +1,177 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compare_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPARE_VERSION(VERSION_A, OP, VERSION_B, [ACTION-IF-TRUE], [ACTION-IF-FALSE])
+#
+# DESCRIPTION
+#
+#   This macro compares two version strings. Due to the various number of
+#   minor-version numbers that can exist, and the fact that string
+#   comparisons are not compatible with numeric comparisons, this is not
+#   necessarily trivial to do in a autoconf script. This macro makes doing
+#   these comparisons easy.
+#
+#   The six basic comparisons are available, as well as checking equality
+#   limited to a certain number of minor-version levels.
+#
+#   The operator OP determines what type of comparison to do, and can be one
+#   of:
+#
+#    eq  - equal (test A == B)
+#    ne  - not equal (test A != B)
+#    le  - less than or equal (test A <= B)
+#    ge  - greater than or equal (test A >= B)
+#    lt  - less than (test A < B)
+#    gt  - greater than (test A > B)
+#
+#   Additionally, the eq and ne operator can have a number after it to limit
+#   the test to that number of minor versions.
+#
+#    eq0 - equal up to the length of the shorter version
+#    ne0 - not equal up to the length of the shorter version
+#    eqN - equal up to N sub-version levels
+#    neN - not equal up to N sub-version levels
+#
+#   When the condition is true, shell commands ACTION-IF-TRUE are run,
+#   otherwise shell commands ACTION-IF-FALSE are run. The environment
+#   variable 'ax_compare_version' is always set to either 'true' or 'false'
+#   as well.
+#
+#   Examples:
+#
+#     AX_COMPARE_VERSION([3.15.7],[lt],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[lt],[3.15.8])
+#
+#   would both be true.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[gt],[3.15.8])
+#
+#   would both be false.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq2],[3.15.8])
+#
+#   would be true because it is only comparing two minor versions.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq0],[3.15])
+#
+#   would be true because it is only comparing the lesser number of minor
+#   versions of the two values.
+#
+#   Note: The characters that separate the version numbers do not matter. An
+#   empty string is the same as version 0. OP is evaluated by autoconf, not
+#   configure, so must be a string, not a variable.
+#
+#   The author would like to acknowledge Guido Draheim whose advice about
+#   the m4_case and m4_ifvaln functions make this macro only include the
+#   portions necessary to perform the specific comparison specified by the
+#   OP argument in the final configure script.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Tim Toolan <toolan@ele.uri.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 12
+
+dnl #########################################################################
+AC_DEFUN([AX_COMPARE_VERSION], [
+  AC_REQUIRE([AC_PROG_AWK])
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+  AS_VAR_PUSHDEF([A],[ax_compare_version_A])
+  A=`echo "$1" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  AS_VAR_PUSHDEF([B],[ax_compare_version_B])
+  B=`echo "$3" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  dnl # In the case of le, ge, lt, and gt, the strings are sorted as necessary
+  dnl # then the first line is used to determine if the condition is true.
+  dnl # The sed right after the echo is to remove any indented white space.
+  m4_case(m4_tolower($2),
+  [lt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [gt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [le],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],
+  [ge],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],[
+    dnl Split the operator from the subversion count if present.
+    m4_bmatch(m4_substr($2,2),
+    [0],[
+      # A count of zero means use the length of the shorter version.
+      # Determine the number of characters in A and B.
+      ax_compare_version_len_A=`echo "$A" | $AWK '{print(length)}'`
+      ax_compare_version_len_B=`echo "$B" | $AWK '{print(length)}'`
+
+      # Set A to no more than B's length and B to no more than A's length.
+      A=`echo "$A" | sed "s/\(.\{$ax_compare_version_len_B\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(.\{$ax_compare_version_len_A\}\).*/\1/"`
+    ],
+    [[0-9]+],[
+      # A count greater than zero means use only that many subversions
+      A=`echo "$A" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+    ],
+    [.+],[
+      AC_WARNING(
+        [illegal OP numeric parameter: $2])
+    ],[])
+
+    # Pad zeros at end of numbers to make same length.
+    ax_compare_version_tmp_A="$A`echo $B | sed 's/./0/g'`"
+    B="$B`echo $A | sed 's/./0/g'`"
+    A="$ax_compare_version_tmp_A"
+
+    # Check for equality or inequality as necessary.
+    m4_case(m4_tolower(m4_substr($2,0,2)),
+    [eq],[
+      test "x$A" = "x$B" && ax_compare_version=true
+    ],
+    [ne],[
+      test "x$A" != "x$B" && ax_compare_version=true
+    ],[
+      AC_WARNING([illegal OP parameter: $2])
+    ])
+  ])
+
+  AS_VAR_POPDEF([A])dnl
+  AS_VAR_POPDEF([B])dnl
+
+  dnl # Execute ACTION-IF-TRUE / ACTION-IF-FALSE.
+  if test "$ax_compare_version" = "true" ; then
+    m4_ifvaln([$4],[$4],[:])dnl
+    m4_ifvaln([$5],[else $5])dnl
+  fi
+]) dnl AX_COMPARE_VERSION

--- a/config/dpdk.m4
+++ b/config/dpdk.m4
@@ -50,10 +50,9 @@ if test ${RTE_TARGET}x = x; then
 	AC_MSG_ERROR([urdma requires DPDK.  Set RTE_TARGET to the DPDK compilation target])
 fi
 
-DPDK_CPPFLAGS="-I${RTE_SDK}/${RTE_TARGET}/include"
-AC_SUBST([DPDK_CPPFLAGS])
-DPDK_LDFLAGS="-L${RTE_SDK}/${RTE_TARGET}/lib"
-AC_SUBST([DPDK_LDFLAGS])
+AC_SUBST([DPDK_CPPFLAGS], ["-I${RTE_SDK}/${RTE_TARGET}/include"])
+AC_SUBST([DPDK_LDFLAGS], ["-L${RTE_SDK}/${RTE_TARGET}/lib"])
+AC_SUBST([DPDK_LIBS], ["-Wl,--whole-archive,-ldpdk,--no-whole-archive -ldpdk"])
 
 AC_CACHE_CHECK([for DPDK machine compiler flags],
 [urdma_cv_cflags_machine], [cat >conftest.make <<_EOF
@@ -79,12 +78,11 @@ AC_SUBST([DPDK_CFLAGS])
 old_CFLAGS="${CFLAGS}"
 old_CPPFLAGS="${CPPFLAGS}"
 old_LDFLAGS="${LDFLAGS}"
+old_LIBS="${LIBS}"
 CFLAGS="${CFLAGS} ${DPDK_CFLAGS}"
 CPPFLAGS="${CPPFLAGS} ${DPDK_CPPFLAGS}"
 LDFLAGS="${CPPFLAGS} ${DPDK_LDFLAGS}"
-
-old_LIBS="${LIBS}"
-LIBS="-ldpdk ${LIBS}"
+LIBS="${DPDK_LIBS} ${LIBS}"
 
 AC_CHECK_HEADERS([rte_version.h], [],
 		 [AC_MSG_ERROR([urdma requires DPDK >= $1])])
@@ -123,13 +121,10 @@ esac
 ])
 
 
-LIBS=${old_LIBS}
-DPDK_LIBS="-Wl,--whole-archive,-ldpdk,--no-whole-archive"
-AC_SUBST([DPDK_LIBS])
-
 CFLAGS="${old_CFLAGS}"
 CPPFLAGS="${old_CPPFLAGS}"
 LDFLAGS="${old_LDFLAGS}"
+LIBS=${old_LIBS}
 ]) # URDMA_LIB_DPDK
 
 # DPDK_CHECK_FUNC(FUNCTION, [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])

--- a/config/dpdk.m4
+++ b/config/dpdk.m4
@@ -1,0 +1,119 @@
+# Userspace Software iWARP library for DPDK
+#
+# Authors: Patrick MacArthur <patrick@patrickmacarthur.net>
+#
+# Copyright (c) 2016-2017, University of New Hampshire
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# BSD license below:
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#   - Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#   - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+#   - Neither the name of IBM nor the names of its contributors may be
+#     used to endorse or promote products derived from this software without
+#     specific prior written permission.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# URDMA_LIB_DPDK
+# --------------
+# Checks that we have DPDK, and optionally checks that the version is at
+# least the one requested. Note that this macro will abort if DPDK is
+# not found; fixing this would take more effort than it is worth.
+AC_DEFUN([URDMA_LIB_DPDK],
+[
+AC_ARG_VAR([RTE_SDK], [Location of DPDK SDK installation])
+AC_ARG_VAR([RTE_TARGET], [DPDK target system and toolchain])
+if test ${RTE_SDK}x = x; then
+	AC_MSG_ERROR([urdma requires DPDK.  Set RTE_SDK to the DPDK install location])
+fi
+if test ${RTE_TARGET}x = x; then
+	AC_MSG_ERROR([urdma requires DPDK.  Set RTE_TARGET to the DPDK compilation target])
+fi
+
+DPDK_CPPFLAGS="-I${RTE_SDK}/${RTE_TARGET}/include -include rte_config.h"
+AC_SUBST([DPDK_CPPFLAGS])
+DPDK_LDFLAGS="-L${RTE_SDK}/${RTE_TARGET}/lib"
+AC_SUBST([DPDK_LDFLAGS])
+
+AC_CACHE_CHECK([for DPDK machine compiler flags],
+[urdma_cv_cflags_machine], [cat >conftest.make <<_EOF
+SHELL = /bin/sh
+include \$(RTE_SDK)/mk/rte.vars.mk
+.PHONY: all
+all:
+	@echo 'MACHINE_CFLAGS=\$(MACHINE_CFLAGS)'
+_EOF
+result=`${MAKE-make} -f conftest.make 2>/dev/null | grep MACHINE_CFLAGS=`
+AS_CASE([$result],
+	[MACHINE_CFLAGS=*],
+	[urdma_cv_cflags_machine=`printf %s "$result" | sed -e 's/^MACHINE_CFLAGS=//'`],
+	[urdma_cv_cflags_machine="not found"])
+AS_UNSET([result])
+rm -f conftest.make])
+if test "x$urdma_cv_cflags_machine" = "xnot found"; then
+	AC_MSG_ERROR([Could not detect DPDK compiler flags; check your DPDK installation])
+fi
+MACHINE_CFLAGS=$urdma_cv_cflags_machine
+AC_SUBST([MACHINE_CFLAGS])
+
+old_CFLAGS="${CFLAGS}"
+old_CPPFLAGS="${CPPFLAGS}"
+old_LDFLAGS="${LDFLAGS}"
+CFLAGS="${CFLAGS} ${MACHINE_CFLAGS}"
+CPPFLAGS="${CPPFLAGS} ${DPDK_CPPFLAGS}"
+LDFLAGS="${CPPFLAGS} ${DPDK_LDFLAGS}"
+AC_CHECK_HEADERS([rte_ethdev.h], [],
+[AC_MSG_ERROR([urdma requires DPDK >= 16.07])])
+
+old_LIBS="${LIBS}"
+LIBS="-ldpdk ${LIBS}"
+AC_MSG_CHECKING([for DPDK 16.07 built as shared libraries])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(
+[[#include <rte_eal.h>
+ #include <rte_ethdev.h>]],
+[[int main(int argc, char *argv[]) {
+	struct rte_eth_dev_info info;
+	rte_eal_init(argc, argv);
+	info.nb_rx_queues = 1;
+	return 0;
+}]])],
+	[AC_MSG_RESULT([yes])],
+	[AC_MSG_RESULT([no])]
+	[AC_MSG_ERROR([urdma requires DPDK >= 16.07])])
+
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <rte_kni.h>]],
+	       [[int main(int argc, char *argv[]) {
+			rte_eal_init(argc, argv);
+			rte_kni_init(1);
+			return 0;
+		}]])], [],
+[AC_MSG_ERROR([urdma requires that DPDK be built with KNI support])])
+
+LIBS=${old_LIBS}
+DPDK_LIBS="-Wl,--whole-archive,-ldpdk,--no-whole-archive"
+AC_SUBST([DPDK_LIBS])
+
+CFLAGS="${old_CFLAGS}"
+CPPFLAGS="${old_CPPFLAGS}"
+LDFLAGS="${old_LDFLAGS}"
+])

--- a/config/dpdk.m4
+++ b/config/dpdk.m4
@@ -50,7 +50,7 @@ if test ${RTE_TARGET}x = x; then
 	AC_MSG_ERROR([urdma requires DPDK.  Set RTE_TARGET to the DPDK compilation target])
 fi
 
-DPDK_CPPFLAGS="-I${RTE_SDK}/${RTE_TARGET}/include -include rte_config.h"
+DPDK_CPPFLAGS="-I${RTE_SDK}/${RTE_TARGET}/include"
 AC_SUBST([DPDK_CPPFLAGS])
 DPDK_LDFLAGS="-L${RTE_SDK}/${RTE_TARGET}/lib"
 AC_SUBST([DPDK_LDFLAGS])

--- a/config/dpdk.m4
+++ b/config/dpdk.m4
@@ -73,13 +73,13 @@ rm -f conftest.make])
 if test "x$urdma_cv_cflags_machine" = "xnot found"; then
 	AC_MSG_ERROR([Could not detect DPDK compiler flags; check your DPDK installation])
 fi
-MACHINE_CFLAGS=$urdma_cv_cflags_machine
-AC_SUBST([MACHINE_CFLAGS])
+DPDK_CFLAGS=$urdma_cv_cflags_machine
+AC_SUBST([DPDK_CFLAGS])
 
 old_CFLAGS="${CFLAGS}"
 old_CPPFLAGS="${CPPFLAGS}"
 old_LDFLAGS="${LDFLAGS}"
-CFLAGS="${CFLAGS} ${MACHINE_CFLAGS}"
+CFLAGS="${CFLAGS} ${DPDK_CFLAGS}"
 CPPFLAGS="${CPPFLAGS} ${DPDK_CPPFLAGS}"
 LDFLAGS="${CPPFLAGS} ${DPDK_LDFLAGS}"
 AC_CHECK_HEADERS([rte_ethdev.h], [],
@@ -123,7 +123,7 @@ _dpdkcf_old_CPPFLAGS="${CPPFLAGS}"
 _dpdkcf_old_LDFLAGS="${LDFLAGS}"
 _dpdkcf_old_LIBS="${LIBS}"
 
-CFLAGS="${CFLAGS} ${MACHINE_CFLAGS}"
+CFLAGS="${CFLAGS} ${DPDK_CFLAGS}"
 CPPFLAGS="${CPPFLAGS} ${DPDK_CPPFLAGS}"
 LDFLAGS="${CPPFLAGS} ${DPDK_LDFLAGS}"
 LIBS="${DPDK_LIBS} ${LIBS}"

--- a/config/version.sh
+++ b/config/version.sh
@@ -46,7 +46,7 @@ fi
 if [ -f .version ]; then
 	cat .version
 elif [ -d .git ]; then
-	echo -n $(git describe --abbrev=12)
+	echo -n $(git describe --abbrev=12 | sed -e 's/^v//')
 else
 	printf 'unknown\n' >&2
 	exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,14 @@ URDMA_LIB_DPDK([16.07])
 
 DPDK_CHECK_FUNC([rte_kni_init], [],
 	      [AC_MSG_ERROR([urdma requires that DPDK be built with KNI support])])
+DPDK_FUNC_RTE_RING_DEQUEUE_BURST
+if test "x$dpdk_cv_func_which_rte_ring_dequeue_burst" = "xno"; then
+	AC_MSG_ERROR([urdma requires rte_ring_dequeue_burst; check your DPDK installation])
+fi
+DPDK_FUNC_RTE_RING_ENQUEUE_BURST
+if test "x$dpdk_cv_func_which_rte_ring_enqueue_burst" = "xno"; then
+	AC_MSG_ERROR([urdma requires rte_ring_enqueue_burst; check your DPDK installation])
+fi
 
 AC_CONFIG_FILES([Makefile src/kmod/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,7 @@ AC_CHECK_HEADERS([sys/socket.h], [],
 AC_CHECK_DECLS([SOCK_CLOEXEC], [], [], [AC_INCLUDES_DEFAULT()]
 [[#include <sys/socket.h>]])
 
-URDMA_LIB_DPDK
+URDMA_LIB_DPDK([16.07])
 
 DPDK_CHECK_FUNC([rte_kni_init], [],
 	      [AC_MSG_ERROR([urdma requires that DPDK be built with KNI support])])

--- a/configure.ac
+++ b/configure.ac
@@ -83,9 +83,15 @@ unexpected value ATOMIC_INT_LOCK_FREE
 _URDMA_EOF
 		urdma_cv_c_atomic_int_lock_free=`$CC $CPPFLAGS -E $dummy.c 2> /dev/null | tail -1`
 		rm -f $dummy.c]])
-if test "x$urdma_cv_c_atomic_int_lock_free" != xyes; then
-      AC_MSG_ERROR([you must use a compiler that makes atomic_int lock free])
-fi
+case "$urdma_cv_c_atomic_int_lock_free" in #(
+yes) ;; #(
+no)
+	AC_MSG_ERROR([you must use a compiler that makes atomic_int lock free])
+	;; #(
+*)
+	AC_MSG_WARN([your compiler does not guarantee that atomics work in multiprocess context])
+	;;
+esac
 
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET

--- a/configure.ac
+++ b/configure.ac
@@ -98,43 +98,8 @@ AC_PROG_MAKE_SET
 AM_PROG_CC_C_O
 AC_PROG_MKDIR_P
 
-AC_ARG_VAR([RTE_SDK], [Location of DPDK SDK installation])
-AC_ARG_VAR([RTE_TARGET], [DPDK target system and toolchain])
 AC_ARG_VAR([KERNELDIR], [kernel source directory])
 AC_SUBST([KERNELDIR])
-if test ${RTE_SDK}x = x; then
-	AC_MSG_ERROR([urdma requires DPDK.  Set RTE_SDK to the DPDK install location])
-fi
-if test ${RTE_TARGET}x = x; then
-	AC_MSG_ERROR([urdma requires DPDK.  Set RTE_TARGET to the DPDK compilation target])
-fi
-
-DPDK_CPPFLAGS="-I${RTE_SDK}/${RTE_TARGET}/include -include rte_config.h"
-AC_SUBST([DPDK_CPPFLAGS])
-DPDK_LDFLAGS="-L${RTE_SDK}/${RTE_TARGET}/lib"
-AC_SUBST([DPDK_LDFLAGS])
-
-AC_CACHE_CHECK([for DPDK machine compiler flags],
-[urdma_cv_cflags_machine], [cat >conftest.make <<_EOF
-SHELL = /bin/sh
-include \$(RTE_SDK)/mk/rte.vars.mk
-.PHONY: all
-all:
-	@echo 'MACHINE_CFLAGS=\$(MACHINE_CFLAGS)'
-_EOF
-result=`${MAKE-make} -f conftest.make 2>/dev/null | grep MACHINE_CFLAGS=`
-AS_CASE([$result],
-	[MACHINE_CFLAGS=*],
-	[urdma_cv_cflags_machine=`printf %s "$result" | sed -e 's/^MACHINE_CFLAGS=//'`],
-	[urdma_cv_cflags_machine="not found"])
-AS_UNSET([result])
-rm -f conftest.make])
-if test "x$urdma_cv_cflags_machine" = "xnot found"; then
-	AC_MSG_ERROR([Could not detect DPDK compiler flags; check your DPDK installation])
-fi
-MACHINE_CFLAGS=$urdma_cv_cflags_machine
-AC_SUBST([MACHINE_CFLAGS])
-
 AC_MSG_CHECKING([for Linux kernel source tree])
 if test ${KERNELDIR}x = x; then
 	KERNELDIR="/lib/modules/`uname -r`/build"
@@ -218,45 +183,7 @@ AC_CHECK_HEADERS([sys/socket.h], [],
 AC_CHECK_DECLS([SOCK_CLOEXEC], [], [], [AC_INCLUDES_DEFAULT()]
 [[#include <sys/socket.h>]])
 
-old_CFLAGS="${CFLAGS}"
-old_CPPFLAGS="${CPPFLAGS}"
-old_LDFLAGS="${LDFLAGS}"
-CFLAGS="${CFLAGS} ${MACHINE_CFLAGS}"
-CPPFLAGS="${CPPFLAGS} ${DPDK_CPPFLAGS}"
-LDFLAGS="${CPPFLAGS} ${DPDK_LDFLAGS}"
-AC_CHECK_HEADERS([rte_ethdev.h], [],
-[AC_MSG_ERROR([urdma requires DPDK >= 16.07])])
-
-old_LIBS="${LIBS}"
-LIBS="-ldpdk ${LIBS}"
-AC_MSG_CHECKING([for DPDK 16.07 built as shared libraries])
-AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[#include <rte_eal.h>
- #include <rte_ethdev.h>]],
-[[int main(int argc, char *argv[]) {
-	struct rte_eth_dev_info info;
-	rte_eal_init(argc, argv);
-	info.nb_rx_queues = 1;
-	return 0;
-}]])],
-	[AC_MSG_RESULT([yes])],
-	[AC_MSG_RESULT([no])]
-	[AC_MSG_ERROR([urdma requires DPDK >= 16.07])])
-LIBS=${old_LIBS}
-DPDK_LIBS="-Wl,--whole-archive,-ldpdk,--no-whole-archive"
-AC_SUBST([DPDK_LIBS])
-
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <rte_kni.h>]],
-	       [[int main(int argc, char *argv[]) {
-			rte_eal_init(argc, argv);
-			rte_kni_init(1);
-			return 0;
-		}]])], [],
-[AC_MSG_ERROR([urdma requires that DPDK be built with KNI support])])
-
-CFLAGS="${old_CFLAGS}"
-CPPFLAGS="${old_CPPFLAGS}"
-LDFLAGS="${old_LDFLAGS}"
+URDMA_LIB_DPDK
 
 AC_CONFIG_FILES([Makefile src/kmod/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,9 @@ AC_CHECK_DECLS([SOCK_CLOEXEC], [], [], [AC_INCLUDES_DEFAULT()]
 
 URDMA_LIB_DPDK
 
+DPDK_CHECK_FUNC([rte_kni_init], [],
+	      [AC_MSG_ERROR([urdma requires that DPDK be built with KNI support])])
+
 AC_CONFIG_FILES([Makefile src/kmod/Makefile])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -135,11 +135,15 @@ fi
 MACHINE_CFLAGS=$urdma_cv_cflags_machine
 AC_SUBST([MACHINE_CFLAGS])
 
+AC_MSG_CHECKING([for Linux kernel source tree])
 if test ${KERNELDIR}x = x; then
 	KERNELDIR="/lib/modules/`uname -r`/build"
 fi
 if test ! -f ${KERNELDIR}/Makefile; then
-	AC_MSG_ERROR([urdma requires a kernel source tree.  Install kernel-devel or equivalent])
+	AC_MSG_RESULT([no])
+	AC_MSG_ERROR([urdma requires a Linux kernel source tree.  Install kernel-devel or equivalent])
+else
+	AC_MSG_RESULT([${KERNELDIR}])
 fi
 
 AC_ARG_ENABLE([debug], [AS_HELP_STRING([--enable-debug],

--- a/doc/urdma-schema.json
+++ b/doc/urdma-schema.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "ports": {
+            "type": "array",
+	    "description": "NIC ports to enable",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/port" },
+            "uniqueItems": true
+        },
+        "eal_args": {
+            "type": "object",
+	    "description": "EAL arguments for subprocesses",
+            "properties": {
+                "log-level": {
+		    "type": "number",
+		    "description": "Maximum log level to display"
+		}
+            }
+        },
+	"stats_timer_interval": {
+            "type": "integer",
+            "description": "Interval for urdmad to dump dropped packet statistics"
+	},
+        "socket": {
+            "type": "string",
+            "description": "The location of the socket file for urdmad"
+        }
+    },
+    "additionalProperties": false,
+    "required": [ "ports" ],
+    "definitions": {
+        "port": {
+            "type": "object",
+	    "description": "Settings for the given Ethernet port",
+            "properties": {
+                "ipv4_address": {
+		    "type": "string",
+		    "description": "IPv4 address to assign to the port"
+		},
+                "mtu": {
+		    "type": "number",
+		    "description": "MTU for the Ethernet port (1500 or 9000)"
+		},
+                "max_qp": {
+		    "type": "number",
+		    "description": "Maximum number of queue pairs to allocate"
+		},
+                "rx_desc_count": {
+		    "type": "number",
+		    "description": "Descriptors per receive queue"
+		},
+                "tx_desc_count": {
+		    "type": "number",
+		    "description": "Descriptors per transmit queue"
+		},
+                "rx_burst_size": {
+		    "type": "number",
+		    "description": "Number of packets to receive at once"
+		},
+                "tx_burst_size": {
+		    "type": "number",
+		    "description": "Number of packets to send at once"
+		}
+            },
+	    "additionalProperties": false
+        }
+    }
+}

--- a/src/kvstore_client/main.c
+++ b/src/kvstore_client/main.c
@@ -53,6 +53,7 @@
 #include <infiniband/verbs.h>
 #include <rdma/rdma_cma.h>
 
+#include <rte_config.h>
 #include <rte_eal.h>
 #include <rte_errno.h>
 #include <rte_ethdev.h>

--- a/src/kvstore_client/options.c
+++ b/src/kvstore_client/options.c
@@ -49,6 +49,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <rte_config.h>
 #include <rte_common.h>
 
 #include "options.h"

--- a/src/kvstore_server/kvstore.c
+++ b/src/kvstore_server/kvstore.c
@@ -52,6 +52,7 @@
 
 #include <math.h>
 
+#include <rte_config.h>
 #include <rte_malloc.h>
 #include <rte_eal.h>
 #include <rte_jhash.h>

--- a/src/kvstore_server/main.c
+++ b/src/kvstore_server/main.c
@@ -52,6 +52,7 @@
 #include <infiniband/verbs.h>
 #include <rdma/rdma_cma.h>
 
+#include <rte_config.h>
 #include <rte_eal.h>
 #include <rte_errno.h>
 #include <rte_ethdev.h>

--- a/src/kvstore_server/options.c
+++ b/src/kvstore_server/options.c
@@ -44,6 +44,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <rte_config.h>
 #include <rte_common.h>
 
 #include "options.h"

--- a/src/liburdma/driver.c
+++ b/src/liburdma/driver.c
@@ -55,6 +55,7 @@
 
 #include <infiniband/driver.h>
 
+#include <rte_config.h>
 #include <rte_ethdev.h>
 #include <rte_errno.h>
 #include <rte_ip.h>

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -1128,7 +1128,7 @@ dequeue_recv_wqes(struct usiw_qp *qp)
 	struct usiw_recv_wqe *wqe[qp->rq0.max_wr + 1];
 	unsigned int i, ret;
 
-	while ((ret = rte_ring_dequeue_burst(qp->rq0.ring, (void **)wqe,
+	while ((ret = RING_DEQUEUE_BURST(qp->rq0.ring, (void **)wqe,
 						qp->rq0.max_wr + 1)) > 0) {
 		for (i = 0; i < ret; i++) {
 			wqe[i]->remote_ep = &qp->remote_ep;
@@ -1980,7 +1980,7 @@ process_receive_queue(struct usiw_qp *qp, void *prefetch_addr, uint64_t *now)
 				qp->shm_qp->rx_queue,
 				rxmbuf, qp->shm_qp->rx_burst_size);
 	} else if (qp->remote_ep.rx_queue) {
-		rx_count = rte_ring_dequeue_burst(qp->remote_ep.rx_queue,
+		rx_count = RING_DEQUEUE_BURST(qp->remote_ep.rx_queue,
 				(void **)rxmbuf, qp->shm_qp->rx_burst_size);
 	} else {
 		rx_count = 0;
@@ -2259,7 +2259,7 @@ kni_loop(void *arg)
 	driver = arg;
 	sem_wait(&driver->go);
 	while (1) {
-		count = rte_ring_dequeue_burst(driver->new_ctxs, ctxs_to_add,
+		count = RING_DEQUEUE_BURST(driver->new_ctxs, ctxs_to_add,
 					     NEW_CTX_MAX);
 		for (i = 0; i < count; ++i) {
 			h = (struct usiw_context_handle *)ctxs_to_add[i];

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -51,6 +51,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <rte_config.h>
 #include <rte_arp.h>
 #include <rte_cycles.h>
 #include <rte_eal.h>

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -81,6 +81,22 @@
 #define STAG_TYPE_RDMA_READ (UINT32_C(0x01) << 24)
 #define STAG_RDMA_READ(x) (STAG_TYPE_RDMA_READ | ((x) & STAG_MASK))
 
+#if defined(HAVE_FUNC_RTE_RING_DEQUEUE_BURST_4)
+#define RING_DEQUEUE_BURST(a, b, c) (rte_ring_dequeue_burst((a), (b), (c), NULL))
+#elif defined(HAVE_FUNC_RTE_RING_DEQUEUE_BURST_3)
+#define RING_DEQUEUE_BURST(a, b, c) (rte_ring_dequeue_burst((a), (b), (c)))
+#else
+#error rte_ring_dequeue_burst not available
+#endif
+
+#if defined(HAVE_FUNC_RTE_RING_ENQUEUE_BURST_4)
+#define RING_ENQUEUE_BURST(a, b, c) (rte_ring_enqueue_burst((a), (b), (c), NULL))
+#elif defined(HAVE_FUNC_RTE_RING_ENQUEUE_BURST_3)
+#define RING_ENQUEUE_BURST(a, b, c) (rte_ring_enqueue_burst((a), (b), (c)))
+#else
+#error rte_ring_enqueue_burst not available
+#endif
+
 struct usiw_context;
 struct usiw_device;
 struct usiw_qp;

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -50,6 +50,7 @@
 
 #include <uthash.h>
 
+#include <rte_config.h>
 #include <rte_ethdev.h>
 #include <rte_ether.h>
 #include <rte_kni.h>

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -49,6 +49,7 @@
 
 #include <infiniband/driver.h>
 
+#include <rte_config.h>
 #include <rte_ethdev.h>
 #include <rte_errno.h>
 #include <rte_ip.h>

--- a/src/liburdma/verbs.c
+++ b/src/liburdma/verbs.c
@@ -589,12 +589,12 @@ do_poll_cq(struct usiw_cq *cq, int num_entries, struct usiw_wc *wc)
 	void *cqe[num_entries];
 	int count, x, ret;
 
-	count = rte_ring_dequeue_burst(cq->cqe_ring, cqe, num_entries);
+	count = RING_DEQUEUE_BURST(cq->cqe_ring, cqe, num_entries);
 	if (count >= 0) {
 		for (x = 0; x < count; ++x) {
 			memcpy(&wc[x], cqe[x], sizeof(struct usiw_wc));
 		}
-		ret = rte_ring_enqueue_burst(cq->free_ring, cqe, count);
+		ret = RING_ENQUEUE_BURST(cq->free_ring, cqe, count);
 		assert(ret == count);
 		if (ret < 0) {
 			count = ret;

--- a/src/mkkvstore/main.c
+++ b/src/mkkvstore/main.c
@@ -56,6 +56,7 @@
 
 #include <math.h>
 
+#include <rte_config.h>
 #include <rte_malloc.h>
 #include <rte_eal.h>
 #include <rte_jhash.h>

--- a/src/udp_pingpong/main.c
+++ b/src/udp_pingpong/main.c
@@ -55,6 +55,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <rte_config.h>
 #include <rte_arp.h>
 #include <rte_cycles.h>
 #include <rte_eal.h>

--- a/src/urdmad/kni.c
+++ b/src/urdmad/kni.c
@@ -42,6 +42,7 @@
 #endif
 
 #include <assert.h>
+#include <rte_config.h>
 #include <rte_kni.h>
 #include <netlink/msg.h>
 #include <netlink/netlink.h>

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -57,6 +57,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <rte_config.h>
 #include <rte_ethdev.h>
 #include <rte_errno.h>
 #include <rte_ip.h>

--- a/src/verbs_pingpong/main.c
+++ b/src/verbs_pingpong/main.c
@@ -57,6 +57,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <rte_config.h>
 #include <rte_arp.h>
 #include <rte_cycles.h>
 #include <rte_eal.h>


### PR DESCRIPTION
* Make configure no longer abort if the lock-free test cannot be done because the header file does not give a clean 0, 1, or 2.
* Deals properly with tags that begin with "v"
* Refactors the DPDK checks in configure into a new config/dpdk.m4 file which makes it a little more clear what urdma actually requires.
* Depends on the actual version DPDK 16.07 instead of just looking for a field that was added in that version, since we require this version as it has a required bug fix for KNI.
* Updates the README