### PR TITLE
ethdev fixes and mempool driver note

### DIFF
--- a/README
+++ b/README
@@ -115,6 +115,24 @@ Known Issues
    PMD .so files into that directory after DPDK is installed. DPDK will
    then auto-load all .so files in that directory as PMD libraries.
 
+ - DPDK 17.05 introduced the concept of mempool drivers. If you see a
+   message like this using DPDK >= 17.05:
+
+     MBUF: error setting mempool handler
+     EAL: Error - exiting with code: 1
+     Cause: Cannot create rx mempool for port 0 with 8064 mbufs: Invalid argument
+
+   then you do not have a mempool driver by default. This occurs
+   because the linker has been configured with --as-needed by default on
+   some distributions, and since the mempool and PMD drivers do not
+   declare any symbols, the linker has no way of knowing that we depend
+   on the presence of a mempool driver.
+
+   Like the PMD issue above, you can pass -d to load the default
+   librte_mempool_ring driver on the command line, or set
+   CONFIG_RTE_EAL_PMD_PATH and place mempool driver(s) into that
+   directory.
+
  - There is a potential race condition with completion channels, where a
    completion event can get lost, and thus a thread waiting on
    ibv_get_cq_event() will never wake up, leading to a deadlock.  A cause has

--- a/TODO
+++ b/TODO
@@ -1,4 +1,9 @@
-libusiw
+build system
+  - Explicitly link in DPDK libraries instead of using -ldpdk as a
+    shortcut, to avoid interference from distributions which use
+    --as-needed by default.
+
+liburdma
   - Choose rte_mempool sizes dynamically, and choose maximum number of queue
     pairs and tx/rx ring size according to the rte_mempool size
   - Add static inlines to wrap all container_of()'s

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -74,6 +74,9 @@
 #include "urdmad_private.h"
 #include "urdma_kabi.h"
 
+/* ixgbe and e1000 drivers require space for a VLAN tag in the receive mbufs;
+ * in the case of ixgbe this is twice the space of the VLAN header */
+static const size_t urdma_vlan_space = 8;
 
 static struct usiw_driver *driver;
 
@@ -731,6 +734,7 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 	struct rte_eth_txconf txconf;
 	struct rte_eth_rxconf rxconf;
 	struct rte_eth_conf port_conf;
+	size_t mbuf_size;
 	int socket_id;
 	int retval;
 	uint16_t q;
@@ -863,11 +867,23 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 				urdmad__entry);
 	}
 
+	/* We must allocate an mbuf large enough to hold the maximum possible
+	 * received packet. Note that the 64-byte headroom does *not* count for
+	 * incoming packets. Note that the MTU as set by urdma and DPDK does
+	 * *not* include the Ethernet header, CRC, or VLAN tag, but the drivers
+	 * require space for these in the receive buffer. */
+	mbuf_size = RTE_PKTMBUF_HEADROOM + port_config->mtu
+		+ ETHER_HDR_LEN + ETHER_CRC_LEN + urdma_vlan_space;
+
 	snprintf(name, RTE_MEMPOOL_NAMESIZE,
 			"port_%u_rx_mempool", iface->portid);
+	RTE_LOG(DEBUG, USER1, "create rx mempool for port %" PRIu16 " with %u mbufs of size %zu\n",
+				iface->portid,
+				2 * iface->max_qp * iface->rx_desc_count,
+				mbuf_size);
 	iface->rx_mempool = rte_pktmbuf_pool_create(name,
 		2 * iface->max_qp * iface->rx_desc_count,
-		0, 0, RTE_PKTMBUF_HEADROOM + port_config->mtu, socket_id);
+		0, 0, mbuf_size, socket_id);
 	if (iface->rx_mempool == NULL)
 		rte_exit(EXIT_FAILURE, "Cannot create rx mempool for port %" PRIu16 " with %u mbufs: %s\n",
 				iface->portid,
@@ -876,10 +892,13 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 
 	snprintf(name, RTE_MEMPOOL_NAMESIZE,
 			"port_%u_tx_mempool", iface->portid);
+	RTE_LOG(DEBUG, USER1, "create tx mempool for port %" PRIu16 " with %u mbufs of size %zu plus %u bytes private data\n",
+				iface->portid,
+				2 * iface->max_qp * iface->rx_desc_count,
+				mbuf_size, PENDING_DATAGRAM_INFO_SIZE);
 	iface->tx_ddp_mempool = rte_pktmbuf_pool_create(name,
 		2 * iface->max_qp * iface->tx_desc_count,
-		0, PENDING_DATAGRAM_INFO_SIZE,
-		RTE_PKTMBUF_HEADROOM + port_config->mtu, socket_id);
+		0, PENDING_DATAGRAM_INFO_SIZE, mbuf_size, socket_id);
 	if (iface->tx_ddp_mempool == NULL)
 		rte_exit(EXIT_FAILURE, "Cannot create tx mempool for port %" PRIu16 " with %u mbufs: %s\n",
 				iface->portid,

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -716,7 +716,7 @@ setup_base_filters(struct usiw_port *iface)
 	retval = rte_eth_dev_filter_ctrl(iface->portid, RTE_ETH_FILTER_FDIR,
 			RTE_ETH_FILTER_SET, &filter_info);
 	if (retval != 0) {
-		rte_exit(EXIT_FAILURE, "Could not set fdir filter info on port %" PRIu16 ": %s\n",
+		RTE_LOG(WARNING, USER1, "Could not set fdir filter info on port %" PRIu16 ": %s\n",
 				iface->portid, strerror(-retval));
 	}
 } /* setup_base_filters */


### PR DESCRIPTION
Fix two issues found by attempting to run with a different PMD driver and update the README with information about DPDK >= 17.05 mempool drivers.