### PR TITLE
urdmad: Implement ntuple filter support

### DIFF
--- a/src/urdmad/interface.h
+++ b/src/urdmad/interface.h
@@ -56,6 +56,8 @@
 enum usiw_port_flags {
 	port_checksum_offload = 1,
 	port_fdir = 2,
+	port_2tuple = 4,
+	port_5tuple = 8,
 };
 
 LIST_HEAD(urdmad_qp_head, urdmad_qp);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -148,6 +148,27 @@ static const struct flag_descr all_speed_capa[] = {
 	{ .flag = 0, .name = NULL },
 };
 
+#define stringify(x) #x
+#define str_case(x) case (x): { return stringify(x); break; }
+
+static const char *dpdk_filter_type_str(int x)
+{
+	switch (x) {
+	str_case(RTE_ETH_FILTER_NONE);
+	str_case(RTE_ETH_FILTER_MACVLAN);
+	str_case(RTE_ETH_FILTER_ETHERTYPE);
+	str_case(RTE_ETH_FILTER_FLEXIBLE);
+	str_case(RTE_ETH_FILTER_SYN);
+	str_case(RTE_ETH_FILTER_NTUPLE);
+	str_case(RTE_ETH_FILTER_TUNNEL);
+	str_case(RTE_ETH_FILTER_FDIR);
+	str_case(RTE_ETH_FILTER_HASH);
+	str_case(RTE_ETH_FILTER_L2_TUNNEL);
+	default:
+		return "unknown";
+	}
+} /* dpdk_filter_type_str */
+
 static void dump_flags(FILE *stream, const struct flag_descr *flags, uint32_t v)
 {
 	const struct flag_descr *ptr;


### PR DESCRIPTION
Currently the only filter type that we support is Flow Director which is
only supported on Intel NICs, since it is the only perfect-match filter
type supported by the i40e driver. This commit adds support for the more
generic ntuple filter type as well, which is supported by at least the
ixgbe and e1000 drivers.

Prefer ntuple to flow director when it is available since ntuple is far
simpler. Prefer 5tuple to 2tuple, but use whichever the NIC supports if
it only supports one or the other.