### PR TITLE
Allow compilation against DPDK 17.11 (#26)

### DIFF
--- a/config/dpdk.m4
+++ b/config/dpdk.m4
@@ -156,14 +156,14 @@ LIBS=${_dpdk_old_LIBS}
 # Like AC_CHECK_FUNC, but add DPDK_LIBS, DPDK_CFLAGS, DPDK_CPPFLAGS, and
 # DPDK_LDFLAGS to their respective variables first and restore them
 # afterward.
-AC_DEFUN([DPDK_CHECK_FUNC], [
+AC_DEFUN([DPDK_CHECK_FUNCS], [
 _WITH_DPDK_FLAGS([
 m4_case([$#],
-	[1], [AC_CHECK_FUNC([$1])],
-	[2], [AC_CHECK_FUNC([$1], [$2])],
-	[3], [AC_CHECK_FUNC([$1], [$2], [$3])],
-	[m4_fatal([DPDK_CHECK_FUNC requires 1-3 arguments])])
-])]) # DPDK_CHECK_FUNC
+	[1], [AC_CHECK_FUNCS([$1])],
+	[2], [AC_CHECK_FUNCS([$1], [$2])],
+	[3], [AC_CHECK_FUNCS([$1], [$2], [$3])],
+	[m4_fatal([DPDK_CHECK_FUNCS requires 1-3 arguments])])
+])]) # DPDK_CHECK_FUNCS
 
 # _DPDK_FUNC_RING_BURST
 # ---------------------
@@ -240,3 +240,38 @@ elif test "x$dpdk_cv_func_which_rte_ring_enqueue_burst" = "x3"; then
 		  [Define to 1 if rte_ring_enqueue_burst takes 3 arguments])
 fi
 ]) # DPDK_FUNC_RTE_RING_ENQUEUE_BURST
+
+# DPDK_CHECK_HEADERS(HEADER-FILE, [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND], [INCLUDES])
+# -------------------------------------------------------------------------------------
+# Like AC_CHECK_HEADERS, but add DPDK_LIBS, DPDK_CFLAGS, DPDK_CPPFLAGS, and
+# DPDK_LDFLAGS to their respective variables first and restore them
+# afterward.
+AC_DEFUN([DPDK_CHECK_HEADERS], [
+_WITH_DPDK_FLAGS([
+m4_case([$#],
+	[1], [AC_CHECK_HEADERS([$1])],
+	[2], [AC_CHECK_HEADERS([$1], [$2])],
+	[3], [AC_CHECK_HEADERS([$1], [$2], [$3])],
+	[4], [AC_CHECK_HEADERS([$1], [$2], [$3], [$4])],
+	[m4_fatal([DPDK_CHECK_HEADERS requires 1-4 arguments])])
+])]) # DPDK_CHECK_HEADERS
+
+# DPDK_CHECK_SIZEOF_PORT_ID()
+# -------------------------------------------------------------------------------------
+# Set HAVE_UINT16_T_PORT_ID if port_id arguments are uint16_t instead of uint8_t.
+AC_DEFUN([DPDK_CHECK_SIZEOF_PORT_ID], [
+_WITH_DPDK_FLAGS([
+CFLAGS="${CFLAGS} -Werror"
+AC_CACHE_CHECK([if port_id is uint16_t],
+	       [urdma_cv_decltype_port_id_uint16_t],
+	       [AC_LINK_IFELSE([AC_LANG_PROGRAM(
+			[[#include <rte_ethdev.h>
+			  #include <stdint.h>]],
+			[[int main(void) { uint16_t x; rte_eth_dev_attach(NULL, &x); return 0; }]])],
+			[urdma_cv_decltype_port_id_uint16_t=yes],
+			[urdma_cv_decltype_port_id_uint16_t=no])])
+if test "x$urdma_cv_decltype_port_id_uint16_t" = xyes; then
+	AC_DEFINE([HAVE_UINT16_T_PORT_ID], [1],
+		  [Define to 1 if DPDK port_id arguments are uint16_t])
+fi
+])]) # DPDK_CHECK_SIZEOF_PORT_ID

--- a/configure.ac
+++ b/configure.ac
@@ -198,8 +198,10 @@ AC_CHECK_DECLS([SOCK_CLOEXEC], [], [], [AC_INCLUDES_DEFAULT()]
 
 URDMA_LIB_DPDK([16.11])
 
-DPDK_CHECK_FUNC([rte_kni_init], [],
+DPDK_CHECK_HEADERS([rte_bus_pci.h])
+DPDK_CHECK_FUNCS([rte_kni_init], [],
 	      [AC_MSG_ERROR([urdma requires that DPDK be built with KNI support])])
+DPDK_CHECK_FUNCS([rte_eth_dev_get_port_by_name rte_eth_dev_get_name_by_port])
 DPDK_FUNC_RTE_RING_DEQUEUE_BURST
 if test "x$dpdk_cv_func_which_rte_ring_dequeue_burst" = "xno"; then
 	AC_MSG_ERROR([urdma requires rte_ring_dequeue_burst; check your DPDK installation])
@@ -208,6 +210,7 @@ DPDK_FUNC_RTE_RING_ENQUEUE_BURST
 if test "x$dpdk_cv_func_which_rte_ring_enqueue_burst" = "xno"; then
 	AC_MSG_ERROR([urdma requires rte_ring_enqueue_burst; check your DPDK installation])
 fi
+DPDK_CHECK_SIZEOF_PORT_ID
 
 AC_CONFIG_FILES([Makefile src/kmod/Makefile])
 AC_OUTPUT

--- a/doc/send-recv.txt
+++ b/doc/send-recv.txt
@@ -18,9 +18,9 @@ Note that messages are generally received in one contiguous buffer, unless the
 port has been configured in advance to segment received packets (note that I
 have not tested this behavior).
 
-To retrieve a message, use the dpdk_eth_recv_burst() function:
+To retrieve a message, use the rte_eth_recv_burst() function:
 
-    int dpdk_eth_rx_burst(uint8_t port, uint16_t queue,
+    int rte_eth_rx_burst(uint16_t port, uint16_t queue,
                           struct dpdk_mbuf **mbuf, const uint16_t count);
 
 This function returns the number of packets retrieved from the queue.  It is

--- a/src/udp_pingpong/main.c
+++ b/src/udp_pingpong/main.c
@@ -232,7 +232,7 @@ port_init(struct port *iface, unsigned int port,
 
 	iface->portid = port;
 	rte_eth_dev_info_get(iface->portid, &dev_info);
-	port_dump_info(stderr, &dev_info);
+	port_dump_info(stderr, iface->portid);
 	fprintf(stderr, "\n");
 	if ((dev_info.tx_offload_capa & required_tx_offloads)
 			!= (required_tx_offloads)) {

--- a/src/urdmad/kni.c
+++ b/src/urdmad/kni.c
@@ -43,6 +43,9 @@
 
 #include <assert.h>
 #include <rte_config.h>
+#ifdef HAVE_RTE_BUS_PCI_H
+#include <rte_bus_pci.h>
+#endif
 #include <rte_kni.h>
 #include <netlink/msg.h>
 #include <netlink/netlink.h>
@@ -56,6 +59,7 @@
 #include "config_file.h"
 #include "interface.h"
 #include "kni.h"
+#include "util.h"
 
 /** nl_errno is expected to be the negated errno value. */
 static int
@@ -141,7 +145,7 @@ get_addr(struct usiw_port *port, const char *ipv4_address_str)
 } /* get_addr */
 
 static int
-port_set_mac_addr(uint8_t port_id, struct rtnl_link *link)
+port_set_mac_addr(uint16_t port_id, struct rtnl_link *link)
 {
 	struct ether_addr bin_addr;
 	struct nl_addr *addr;
@@ -206,7 +210,7 @@ unref_addr:
 } /* usiw_set_ipv4_addr */
 
 static int
-usiw_port_change_mtu(uint8_t port_id, unsigned int new_mtu)
+usiw_port_change_mtu(dpdk_port_id_type port_id, unsigned int new_mtu)
 {
 	RTE_LOG(NOTICE, USER1, "got KNI request to change port %" PRIu8 " MTU to %u\n",
 			port_id, new_mtu);
@@ -214,7 +218,7 @@ usiw_port_change_mtu(uint8_t port_id, unsigned int new_mtu)
 } /* usiw_port_change_mtu */
 
 static const char *
-link_speed_str(uint8_t portid, struct rte_eth_link *link_info)
+link_speed_str(uint16_t portid, struct rte_eth_link *link_info)
 {
 	const char *speed_str;
 
@@ -263,7 +267,7 @@ link_speed_str(uint8_t portid, struct rte_eth_link *link_info)
 } /* link_speed_str */
 
 static int
-usiw_port_change_state(uint8_t port_id, uint8_t if_up)
+usiw_port_change_state(dpdk_port_id_type port_id, uint8_t if_up)
 {
 	struct rte_eth_link link_info;
 	const char *speed_str;

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -1195,24 +1195,6 @@ setup_timer(int interval_ms)
 } /* setup_timer */
 
 
-
-static int
-lookup_ethdev_by_pci_addr(struct rte_pci_addr *addr)
-{
-	struct rte_eth_dev_info info;
-	int x, count;
-
-	count = rte_eth_dev_count();
-	for (x = 0; x < count; ++x) {
-		rte_eth_dev_info_get(x, &info);
-		if (!rte_eal_compare_pci_addr(addr, &info.pci_dev->addr)) {
-			return x;
-		}
-	}
-	return -ENODEV;
-} /* lookup_ethdev_by_pci_addr */
-
-
 static void
 do_init_driver(void)
 {

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -47,6 +47,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <rte_pci.h>
+
 #include "util.h"
 
 int
@@ -239,17 +241,16 @@ desc_lim_dump_info(FILE *stream, struct rte_eth_desc_lim *lim, int indent)
 } /* desc_lim_dump_info */
 
 void
-port_dump_info(FILE *stream, struct rte_eth_dev_info *info)
+port_dump_info(FILE *stream, uint16_t port_id)
 {
+	struct rte_eth_dev_info info_store, *info = &info_store;
+	char namebuf[pci_addr_namebuf_size];
 	char ch;
 	int x;
-
-	fprintf(stream, "\"" PCI_PRI_FMT "\": {\n  \"driver_name\": %s,\n",
-			info->pci_dev->addr.domain,
-			info->pci_dev->addr.bus,
-			info->pci_dev->addr.devid,
-			info->pci_dev->addr.function,
-			info->driver_name);
+	rte_eth_dev_info_get(port_id, info);
+	rte_eth_dev_get_name_by_port(port_id, namebuf);
+	fprintf(stream, "\"%s\": {\n  \"driver_name\": %s,\n",
+			namebuf, info->driver_name);
 	fprintf(stream, "  \"if_index\": %u,\n",
 			info->if_index);
 	fprintf(stream, "  \"min_rx_bufsize\": %" PRIu32 ",\n",


### PR DESCRIPTION
Fix multiple issues compiling against DPDK 17.11:

 - The struct pci_device is now an internal API in the now-undocumented
   rte_bus_pci.h file. Since the KNI demo still references this header,
   we continue to use it for initializing the KNI device. However, we
   no longer use this struct for identifying the port_id of a PCI
   device, instead relying on the rte_eth_dev_get_port_by_name function
   introduced in a previous version of DPDK.

 - The port_id variables in DPDK have been expanded from uint8_t to
   uint16_t. This requires a compile-time check due to KNI callback
   functions which took a pointer to uint8_t previously.

Signed-off-by: Patrick MacArthur <patrick@patrickmacarthur.net>