### PR TITLE
Implement RFC 7306 atomics

### DIFF
--- a/include/proto.h
+++ b/include/proto.h
@@ -73,7 +73,13 @@ enum ddp_queue_number {
 	ddp_queue_send = 0,
 	ddp_queue_read_request = 1,
 	ddp_queue_terminate = 2,
+	ddp_queue_atomic_response = 3,
 	ddp_queue_ack = 4,
+};
+
+enum rdmap_atomic_opcodes {
+	rdmap_atomic_fetchadd = 0,
+	rdmap_atomic_cmpswap = 1,
 };
 
 struct rdmap_tagged_packet {
@@ -115,6 +121,26 @@ struct rdmap_terminate_payload {
 	struct rdmap_packet payload;
 } __attribute__((__packed__));
 
+struct rdmap_atomicreq_packet {
+	struct rdmap_untagged_packet untagged;
+	uint32_t opcode;
+	uint32_t req_id;
+	uint32_t remote_stag;
+	uint64_t remote_offset;
+	uint64_t add_swap_data;
+	uint64_t add_swap_mask;
+	uint64_t compare_data;
+	uint64_t compare_mask;
+} __attribute__((__packed__));
+static_assert(sizeof(struct rdmap_atomicreq_packet) == 70, "unexpected sizeof(rdmap_atomicreq_packet)");
+
+struct rdmap_atomicresp_packet {
+	struct rdmap_untagged_packet untagged;
+	uint32_t req_id;
+	uint64_t orig_value;
+} __attribute__((__packed__));
+static_assert(sizeof(struct rdmap_atomicresp_packet) == 30, "unexpected sizeof(rdmap_atomicresp_packet)");
+
 enum rdmap_packet_type {
 	rdmap_opcode_rdma_write = 0,
 	rdmap_opcode_rdma_read_request = 1,
@@ -124,6 +150,10 @@ enum rdmap_packet_type {
 	rdmap_opcode_send_se = 5,
 	rdmap_opcode_send_se_inv = 6,
 	rdmap_opcode_terminate = 7,
+	rdmap_opcode_imm_data = 8,
+	rdmap_opcode_imm_data_se = 9,
+	rdmap_opcode_atomic_request = 10,
+	rdmap_opcode_atomic_response = 11,
 };
 
 enum /*rdmap_hdrct*/ {

--- a/include/urdmad_private.h
+++ b/include/urdmad_private.h
@@ -141,6 +141,7 @@ struct urdmad_sock_hello_resp {
 	struct urdmad_sock_msg hdr;
 	uint16_t max_lcore;
 	uint16_t device_count;
+	uint64_t rdma_atomic_mutex_addr;
 	uint32_t lcore_mask[RTE_MAX_LCORE / 32];
 	uint16_t max_qp[];
 };

--- a/include/urdmad_private.h
+++ b/include/urdmad_private.h
@@ -50,6 +50,8 @@
 
 #include <rte_ether.h>
 
+#define URDMA_SOCK_PROTO_VERSION 1
+
 /** Internal state machine of the queue pair. */
 enum urdma_qp_state {
 	usiw_qp_unbound = 0,
@@ -134,17 +136,25 @@ struct urdmad_sock_qp_msg {
 
 struct urdmad_sock_hello_req {
 	struct urdmad_sock_msg hdr;
-	uint32_t req_lcore_count;
+	uint8_t proto_version;
+	uint8_t reserved9;
+	uint16_t req_lcore_count;
 };
+static_assert(offsetof(struct urdmad_sock_hello_req, reserved9) == 9,
+		"hello_req reserved9 field is at wrong offset");
 
 struct urdmad_sock_hello_resp {
 	struct urdmad_sock_msg hdr;
-	uint16_t max_lcore;
+	uint8_t proto_version;
+	uint8_t max_lcore;
 	uint16_t device_count;
+	uint32_t reserved12;
 	uint64_t rdma_atomic_mutex_addr;
 	uint32_t lcore_mask[RTE_MAX_LCORE / 32];
 	uint16_t max_qp[];
 };
+static_assert(offsetof(struct urdmad_sock_hello_resp, reserved12) == 12,
+		"reserved12 field is at wrong offset");
 
 union urdmad_sock_any_msg {
 	struct urdmad_sock_msg hdr;

--- a/src/liburdma/driver.c
+++ b/src/liburdma/driver.c
@@ -411,13 +411,15 @@ do_hello(void)
 	struct urdmad_sock_hello_req req;
 	struct urdmad_sock_hello_resp *resp;
 	struct pollfd poll_list;
+	uint32_t lid;
 	int i;
 	ssize_t ret;
 	int resp_size;
 
 	memset(&req, 0, sizeof(req));
 	req.hdr.opcode = rte_cpu_to_be_32(urdma_sock_hello_req);
-	req.req_lcore_count = rte_cpu_to_be_32(1);
+	req.proto_version = URDMA_SOCK_PROTO_VERSION;
+	req.req_lcore_count = rte_cpu_to_be_16(1);
 	ret = send(driver->urdmad_fd, &req, sizeof(req), 0);
 	if (ret != sizeof(req)) {
 		return -1;
@@ -439,6 +441,8 @@ do_hello(void)
 		return -1;
 	}
 
+	if (resp->proto_version != URDMA_SOCK_PROTO_VERSION)
+		return -1;
 	for (i = 0; i < RTE_DIM(resp->lcore_mask); i++) {
 		driver->lcore_mask[i] = rte_be_to_cpu_32(resp->lcore_mask[i]);
 	}

--- a/src/liburdma/driver.c
+++ b/src/liburdma/driver.c
@@ -232,6 +232,7 @@ usiw_driver_init(int portid)
 
 	dev->urdmad_fd = driver->urdmad_fd;
 	dev->max_qp = driver->max_qp[dev->portid];
+	dev->driver = driver;
 
 	return &dev->vdev.device;
 } /* usiw_driver_init */
@@ -442,6 +443,8 @@ do_hello(void)
 		driver->lcore_mask[i] = rte_be_to_cpu_32(resp->lcore_mask[i]);
 	}
 	driver->device_count = rte_be_to_cpu_16(resp->device_count);
+	driver->rdma_atomic_mutex = (void *)(uintptr_t)rte_be_to_cpu_64(
+				resp->rdma_atomic_mutex_addr);
 	driver->max_qp = malloc(driver->device_count * sizeof(*driver->max_qp));
 	if (!driver->max_qp) {
 		return -1;

--- a/src/liburdma/interface.c
+++ b/src/liburdma/interface.c
@@ -219,6 +219,7 @@ usiw_send_wqe_queue_lookup(struct usiw_send_wqe_queue *q,
 		}
 		switch (lptr->opcode) {
 		case usiw_wr_send:
+		case usiw_wr_atomic:
 			if (wr_key_data == lptr->msn) {
 				*wqe = lptr;
 				return 0;
@@ -755,15 +756,25 @@ post_recv_cqe(struct usiw_qp *qp, struct usiw_recv_wqe *wqe,
 
 
 static enum ibv_wc_opcode
-get_ibv_send_wc_opcode(enum usiw_send_opcode ours)
+get_ibv_send_wc_opcode(struct usiw_send_wqe *wqe)
 {
-	switch (ours) {
+	switch (wqe->opcode) {
 	case usiw_wr_send:
 		return IBV_WC_SEND;
 	case usiw_wr_write:
 		return IBV_WC_RDMA_WRITE;
 	case usiw_wr_read:
 		return IBV_WC_RDMA_READ;
+	case usiw_wr_atomic:
+		switch (wqe->atomic_opcode) {
+		case rdmap_atomic_fetchadd:
+			return IBV_WC_FETCH_ADD;
+			break;
+		case rdmap_atomic_cmpswap:
+			return IBV_WC_COMP_SWAP;
+			break;
+		}
+		break;
 	default:
 		assert(0);
 		return -1;
@@ -792,7 +803,7 @@ post_send_cqe(struct usiw_qp *qp, struct usiw_send_wqe *wqe,
 	}
 	cqe->wr_context = wqe->wr_context;
 	cqe->status = status;
-	cqe->opcode = get_ibv_send_wc_opcode(wqe->opcode);
+	cqe->opcode = get_ibv_send_wc_opcode(wqe);
 	cqe->qp_num = qp->ib_qp.qp_num;
 
 	qp_free_send_wqe(qp, wqe, true);
@@ -965,6 +976,60 @@ do_rdmap_write(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 
 
 static void
+do_rdmap_atomic(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
+{
+	struct rdmap_atomicreq_packet *new_rdmap;
+	struct rte_mbuf *sendmsg;
+	unsigned int packet_length;
+
+	if (wqe->state != SEND_WQE_TRANSFER) {
+		return;
+	}
+
+	if (qp->ord_active >= qp->shm_qp->ord_max) {
+		/* Cannot issue more than ord_max simultaneous RDMA READ
+		 * and Atomic Requests. */
+		return;
+	} else if (wqe->remote_ep->send_next_psn
+			== wqe->remote_ep->send_max_psn
+			|| serial_greater_32(wqe->remote_ep->send_next_psn,
+				wqe->remote_ep->send_max_psn)) {
+		/* We have reached the maximum number of credits we are allowed
+		 * to send. */
+		return;
+	}
+	qp->ord_active++;
+
+	sendmsg = rte_pktmbuf_alloc(qp->dev->tx_ddp_mempool);
+
+	packet_length = sizeof(*new_rdmap);
+	new_rdmap = (struct rdmap_atomicreq_packet *)rte_pktmbuf_append(
+				sendmsg, packet_length);
+	new_rdmap->untagged.head.ddp_flags = DDP_V1_UNTAGGED_LAST_DF;
+	new_rdmap->untagged.head.rdmap_info
+		= rdmap_opcode_atomic_request | RDMAP_V1;
+	new_rdmap->untagged.head.sink_stag = rte_cpu_to_be_32(wqe->local_stag);
+	new_rdmap->untagged.qn = rte_cpu_to_be_32(ddp_queue_read_request);
+	new_rdmap->untagged.msn = rte_cpu_to_be_32(wqe->msn);
+	new_rdmap->untagged.mo = rte_cpu_to_be_32(0);
+	new_rdmap->opcode = rte_cpu_to_be_32(wqe->atomic_opcode);
+	new_rdmap->req_id = rte_cpu_to_be_32(wqe->msn);
+	new_rdmap->remote_stag = rte_cpu_to_be_32(wqe->rkey);
+	new_rdmap->remote_offset =
+		rte_cpu_to_be_64((uintptr_t)wqe->remote_addr);
+	new_rdmap->add_swap_data = rte_cpu_to_be_64(wqe->atomic_add_swap);
+	new_rdmap->add_swap_mask = rte_cpu_to_be_64(0);
+	new_rdmap->compare_data = rte_cpu_to_be_64(wqe->atomic_compare);
+	new_rdmap->compare_mask = rte_cpu_to_be_64(0);
+
+	send_ddp_segment(qp, sendmsg, NULL, wqe, 0);
+	RTE_LOG(DEBUG, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> ATOMIC transmit msn=%" PRIu32 "\n",
+			qp->shm_qp->dev_id, qp->shm_qp->qp_id, wqe->msn);
+
+	wqe->state = SEND_WQE_WAIT;
+} /* do_rdmap_atomic */
+
+static void
 do_rdmap_read_request(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 {
 	struct rdmap_readreq_packet *new_rdmap;
@@ -1008,6 +1073,8 @@ do_rdmap_read_request(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 	new_rdmap->source_offset = rte_cpu_to_be_64(wqe->remote_addr);
 
 	send_ddp_segment(qp, sendmsg, NULL, wqe, 0);
+	RTE_LOG(DEBUG, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> RDMA READ transmit msn=%" PRIu32 "\n",
+			qp->shm_qp->dev_id, qp->shm_qp->qp_id, wqe->msn);
 
 	wqe->state = SEND_WQE_WAIT;
 } /* do_rdmap_read_request */
@@ -1522,7 +1589,8 @@ try_complete_wqe(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 			qp_free_send_wqe(qp, wqe, true);
 		}
 		rte_spinlock_unlock(&qp->sq.lock);
-		if (wqe->opcode == usiw_wr_read) {
+		if (wqe->opcode == usiw_wr_read
+				|| wqe->opcode == usiw_wr_atomic) {
 			assert(qp->ord_active > 0);
 			qp->ord_active--;
 		}
@@ -1531,11 +1599,12 @@ try_complete_wqe(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 
 
 static struct usiw_send_wqe *
-find_first_rdma_read(struct usiw_qp *qp)
+find_first_rdma_read_atomic(struct usiw_qp *qp)
 {
 	struct usiw_send_wqe *lptr, *next;
 	list_for_each_safe(&qp->sq.active_head, lptr, next, active) {
-		if (lptr->opcode == usiw_wr_read) {
+		if (lptr->opcode == usiw_wr_read
+				|| lptr->opcode == usiw_wr_atomic) {
 			return lptr;
 		}
 	}
@@ -1572,6 +1641,42 @@ process_rdma_read_response(struct usiw_qp *qp, struct packet_context *orig)
 		binheap_insert(qp->remote_ep.recv_rresp_last_psn, orig->psn);
 	}
 }	/* process_rdma_read_response */
+
+
+static void
+process_atomic_response(struct usiw_qp *qp, struct packet_context *orig)
+{
+	struct rdmap_atomicresp_packet *rdmap;
+	struct usiw_send_wqe *wqe;
+	uint16_t wqe_opcode;
+	int ret;
+
+	/* This ensures that at least one atomic request is active for this
+	 * STag. We don't need to know exactly which one; this just ensures
+	 * that we don't accept a random RDMA READ Response. */
+	rdmap = (struct rdmap_atomicresp_packet *)orig->rdmap;
+	ret = usiw_send_wqe_queue_lookup(&qp->sq, usiw_wr_atomic,
+			rte_be_to_cpu_32(rdmap->req_id), &wqe);
+	if (ret < 0 || !wqe || wqe->opcode != usiw_wr_atomic) {
+		RTE_LOG(DEBUG, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Unexpected atomic response!\n",
+			qp->shm_qp->dev_id, qp->shm_qp->qp_id);
+		do_rdmap_terminate(qp, orig, rdmap_error_opcode_unexpected);
+		return;
+	} else if (!DDP_GET_L(rdmap->untagged.head.ddp_flags)) {
+		RTE_LOG(DEBUG, USER1, "<dev=%" PRIx16 " qp=%" PRIx16 "> Atomic response not single segment!\n",
+			qp->shm_qp->dev_id, qp->shm_qp->qp_id);
+		do_rdmap_terminate(qp, orig,
+				rdmap_error_remote_stream_catastrophic);
+		return;
+	}
+
+	if (wqe->iov_count) {
+		rte_memcpy(wqe->iov[0].iov_base, &rdmap->orig_value,
+				sizeof(rdmap->orig_value));
+	}
+
+	binheap_insert(qp->remote_ep.recv_rresp_last_psn, orig->psn);
+}	/* process_atomic_response */
 
 
 static void
@@ -1693,7 +1798,7 @@ do_process_ack(struct usiw_qp *qp, struct usiw_send_wqe *wqe,
 	wqe->bytes_acked += pending->ddp_length;
 	assert(wqe->bytes_sent >= wqe->bytes_acked);
 
-	if (wqe->opcode != usiw_wr_read
+	if ((wqe->opcode == usiw_wr_send || wqe->opcode == usiw_wr_write)
 			&& wqe->bytes_acked == wqe->total_length) {
 		assert(wqe->state == SEND_WQE_WAIT);
 		wqe->state = SEND_WQE_COMPLETE;
@@ -2100,6 +2205,9 @@ process_data_packet(struct usiw_qp *qp, struct rte_mbuf *mbuf)
 			case rdmap_opcode_atomic_request:
 				process_atomic_request(qp, &ctx);
 				break;
+			case rdmap_opcode_atomic_response:
+				process_atomic_response(qp, &ctx);
+				break;
 			default:
 				do_rdmap_terminate(qp, &ctx,
 						rdmap_error_opcode_unexpected);
@@ -2126,6 +2234,9 @@ progress_send_wqe(struct usiw_qp *qp, struct usiw_send_wqe *wqe)
 		break;
 	case usiw_wr_read:
 		do_rdmap_read_request((struct usiw_qp *)qp, wqe);
+		break;
+	case usiw_wr_atomic:
+		do_rdmap_atomic(qp, wqe);
 		break;
 	}
 } /* progress_send_wqe */
@@ -2202,7 +2313,7 @@ progress_qp(struct usiw_qp *qp)
 			 * the segments in the correct order, and
 			 * try_complete_wqe() ensures that we do not complete an
 			 * RDMA READ request out of order. */
-			send_wqe = find_first_rdma_read(qp);
+			send_wqe = find_first_rdma_read_atomic(qp);
 			if (!(WARN_ONCE(!send_wqe,
 					"No RDMA READ request pending\n"))) {
 				send_wqe->state = SEND_WQE_COMPLETE;
@@ -2236,6 +2347,7 @@ progress_qp(struct usiw_qp *qp)
 							->next_send_msn++;
 					break;
 				case usiw_wr_read:
+				case usiw_wr_atomic:
 					send_wqe->msn = send_wqe->remote_ep
 							->next_read_msn++;
 					break;

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -137,7 +137,7 @@ struct usiw_recv_wqe {
 struct pending_datagram_info {
 	uint64_t next_retransmit;
 	struct usiw_send_wqe *wqe;
-	struct read_response_state *readresp;
+	struct read_atomic_response_state *readresp;
 	uint16_t transmit_count;
 	uint16_t ddp_length;
 	uint32_t ddp_raw_cksum;
@@ -155,6 +155,7 @@ enum usiw_send_opcode {
 	usiw_wr_send = 0,
 	usiw_wr_write = 1,
 	usiw_wr_read = 2,
+	usiw_wr_atomic = 3,
 };
 
 enum {
@@ -242,6 +243,7 @@ struct ee_state {
 
 	/* RX TRP state */
 	uint32_t recv_ack_psn;
+	/* This tracks both READ and atomic responses */
 	struct binheap *recv_rresp_last_psn;
 
 	uint32_t trp_flags;
@@ -256,14 +258,30 @@ struct ee_state {
 	struct rte_ring *rx_queue;
 };
 
-struct read_response_state {
+struct read_atomic_response_state {
 	char *vaddr;
-	uint32_t msg_size;
 	uint32_t sink_stag; /* network byte order */
-	uint64_t sink_offset; /* host byte order */
 	bool active;
-	struct ee_state *sink_ep;
+	enum {
+		read_response,
+		atomic_response,
+	} type;
 	struct list_node qp_entry;
+	struct ee_state *sink_ep;
+
+	union {
+		struct {
+			uint32_t msg_size;
+			uint64_t sink_offset; /* host byte order */
+		} read;
+		struct {
+			unsigned int opcode;
+			uint32_t req_id;
+			uint64_t add_swap;
+			uint64_t compare;
+			bool done;
+		} atomic;
+	};
 };
 
 enum {
@@ -299,7 +317,7 @@ struct usiw_qp {
 	uint64_t timer_last;
 	struct usiw_recv_wqe_queue rq0;
 
-	struct read_response_state *readresp_store;
+	struct read_atomic_response_state *readresp_store;
 	uint32_t readresp_head_msn;
 	uint8_t ord_active;
 
@@ -367,6 +385,7 @@ struct usiw_device {
 	struct rte_mempool *tx_ddp_mempool;
 	struct rte_mempool *tx_hdr_mempool;
 	struct urdmad_queue_range *queue_ranges;
+	struct usiw_driver *driver;
 	uint16_t portid;
 	uint16_t max_qp;
 	uint64_t flags;
@@ -386,6 +405,7 @@ struct usiw_driver {
 	uint32_t lcore_mask[RTE_MAX_LCORE / 32];
 	uint16_t device_count;
 	uint16_t *max_qp;
+	pthread_mutex_t *rdma_atomic_mutex;
 };
 
 /** Starts the progress thread. */

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -168,6 +168,9 @@ struct usiw_send_wqe {
 	void *wr_context;
 	struct ee_state *remote_ep;
 	uint64_t remote_addr;
+	uint64_t atomic_add_swap;
+	uint64_t atomic_compare;
+	uint8_t atomic_opcode;
 	uint32_t rkey;
 	uint32_t flags;
 	struct list_node active;

--- a/src/liburdma/interface.h
+++ b/src/liburdma/interface.h
@@ -281,7 +281,9 @@ struct read_atomic_response_state {
 			unsigned int opcode;
 			uint32_t req_id;
 			uint64_t add_swap;
+			uint64_t add_swap_mask;
 			uint64_t compare;
+			uint64_t compare_mask;
 			bool done;
 		} atomic;
 	};

--- a/src/urdmad/main.c
+++ b/src/urdmad/main.c
@@ -87,6 +87,10 @@ static uint32_t core_mask[RTE_MAX_LCORE / 32];
 static const unsigned int core_mask_shift = 5;
 static const uint32_t core_mask_mask = 31;
 
+static pthread_mutexattr_t pshared_mutexattr;
+/* Mutex for atomic operations */
+static pthread_mutex_t *rdma_atomic_mutex;
+
 static void init_core_mask(void)
 {
 	struct rte_config *config;
@@ -517,6 +521,8 @@ handle_hello(struct urdma_process *process, struct urdmad_sock_hello_req *req)
 	resp->hdr.opcode = rte_cpu_to_be_32(urdma_sock_hello_resp);
 	resp->max_lcore = rte_cpu_to_be_16(RTE_MAX_LCORE);
 	resp->device_count = rte_cpu_to_be_16(driver->port_count);
+	resp->rdma_atomic_mutex_addr =
+		rte_cpu_to_be_64((uintptr_t)rdma_atomic_mutex);
 	for (i = 0; i < RTE_DIM(resp->lcore_mask); i++) {
 		resp->lcore_mask[i] = rte_cpu_to_be_32(process->core_mask[i]);
 	}
@@ -821,7 +827,6 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 		= DEV_TX_OFFLOAD_UDP_CKSUM|DEV_TX_OFFLOAD_IPV4_CKSUM;
 
 	char name[RTE_MEMPOOL_NAMESIZE];
-	pthread_mutexattr_t mutexattr;
 	struct rte_eth_txconf txconf;
 	struct rte_eth_rxconf rxconf;
 	struct rte_eth_conf port_conf;
@@ -960,35 +965,18 @@ usiw_port_init(struct usiw_port *iface, struct usiw_port_config *port_config)
 		rte_exit(EXIT_FAILURE, "Cannot allocate QP array: %s\n",
 				rte_strerror(rte_errno));
 	}
-	retval = pthread_mutexattr_init(&mutexattr);
-	if (retval) {
-		rte_exit(EXIT_FAILURE,
-			"Cannot allocate mutex attribute object: %s\n",
-			rte_strerror(rte_errno));
-	}
-	retval = pthread_mutexattr_setpshared(&mutexattr, PTHREAD_PROCESS_SHARED);
-	if (retval) {
-		rte_exit(EXIT_FAILURE,
-			"Cannot enable process shared mutex attribute: %s\n",
-			rte_strerror(rte_errno));
-	}
 	for (q = 1; q <= iface->max_qp; ++q) {
 		iface->qp[q].qp_id = q;
 		iface->qp[q].tx_queue = q;
 		iface->qp[q].rx_queue = q;
 		atomic_init(&iface->qp[q].conn_state, 0);
-		retval = pthread_mutex_init(&iface->qp[q].conn_event_lock, &mutexattr);
+		retval = pthread_mutex_init(&iface->qp[q].conn_event_lock,
+					    &pshared_mutexattr);
 		if (retval) {
 			rte_exit(EXIT_FAILURE, "Cannot create mutex: %s\n",
 				rte_strerror(rte_errno));
 		}
 		list_add_tail(&iface->avail_qp, &iface->qp[q].urdmad__entry);
-	}
-	retval = pthread_mutexattr_destroy(&mutexattr);
-	if (retval) {
-		rte_exit(EXIT_FAILURE,
-			"Cannot destroy mutex attribute object: %s\n",
-			rte_strerror(rte_errno));
 	}
 
 	/* We must allocate an mbuf large enough to hold the maximum possible
@@ -1233,6 +1221,31 @@ do_init_driver(void)
 	}
 
 	urdma__config_file_close(&config);
+
+	rdma_atomic_mutex = rte_malloc(NULL, sizeof(*rdma_atomic_mutex),
+			RTE_CACHE_LINE_SIZE);
+	if (!rdma_atomic_mutex)
+		rte_exit(EXIT_FAILURE, "Could not allocate atomic mutex: %s\n",
+				strerror(errno));
+	retval = pthread_mutexattr_init(&pshared_mutexattr);
+	if (retval) {
+		rte_exit(EXIT_FAILURE,
+			"Cannot allocate mutex attribute object: %s\n",
+			rte_strerror(rte_errno));
+	}
+	retval = pthread_mutexattr_setpshared(&pshared_mutexattr,
+					      PTHREAD_PROCESS_SHARED);
+	if (retval) {
+		rte_exit(EXIT_FAILURE,
+			"Cannot enable process shared mutex attribute: %s\n",
+			rte_strerror(rte_errno));
+	}
+	retval = pthread_mutex_init(rdma_atomic_mutex, &pshared_mutexattr);
+	if (retval) {
+		rte_exit(EXIT_FAILURE,
+			"Cannot initialize global RDMA atomic mutex: %s\n",
+			rte_strerror(rte_errno));
+	}
 
 	driver = calloc(1, sizeof(*driver)
 			+ port_count * sizeof(struct usiw_port));


### PR DESCRIPTION
This PR adds support for RFC 7306 atomics to urdma. These have been tested using the ib_atomic_lat application provided by perftest.